### PR TITLE
feat(PRIOR-420): Add BCI_MACH_QR to APM checkout lite

### DIFF
--- a/yuno-react/src/components/apm-lite-list/apm-lite-list.tsx
+++ b/yuno-react/src/components/apm-lite-list/apm-lite-list.tsx
@@ -11,6 +11,7 @@ export const ApmListLite: React.FC<{ customLoader: boolean }> = ({ customLoader 
   const isCARD = pmSelected === 'CARD';
   const isPSE = pmSelected === 'PSE';
   const isADDI = pmSelected === 'ADDI';
+  const isBCI_MACH_QR = pmSelected === 'BCI_MACH_QR';
 
   const ComponentApmLite = customLoader ? ApmLiteCustomLoader : ApmLite
 
@@ -39,6 +40,14 @@ export const ApmListLite: React.FC<{ customLoader: boolean }> = ({ customLoader 
         onClick={() => { setPmSelected('ADDI') }}
       />
       {isADDI && <ComponentApmLite paymentMethodType={'ADDI'} onClose={() => { setPmSelected('') }} />}
+    </div>
+    <div>
+      <RadioButton
+        checked={isBCI_MACH_QR}
+        text={'BCI_MACH_QR'}
+        onClick={() => { setPmSelected('BCI_MACH_QR') }}
+      />
+      {isBCI_MACH_QR && <ComponentApmLite paymentMethodType={'BCI_MACH_QR'} onClose={() => { setPmSelected('') }} />}
     </div>
   </Content>
 }


### PR DESCRIPTION
## Summary
- Adds BCI_MACH_QR as a selectable payment method in the APM lite checkout list
- Uses existing generic ApmLite component to render QR + deeplink payment flow for Chilean merchants
- Part of PRIOR-420: BCI/MACH QR + Deeplink APM Integration for Chile

## Changes
- `yuno-react/src/components/apm-lite-list/apm-lite-list.tsx`: Added BCI_MACH_QR radio button and conditional rendering of ApmLite component

## Test plan
- [ ] Verify BCI_MACH_QR radio button appears in checkout lite list
- [ ] Verify selecting BCI_MACH_QR renders ApmLite component with correct paymentMethodType
- [ ] Verify other payment methods (CARD, PSE, ADDI) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds another APM selection and passes a new `paymentMethodType` string through existing `ApmLite` rendering; minimal impact outside this component.
> 
> **Overview**
> Adds a new `BCI_MACH_QR` radio option to `apm-lite-list.tsx` and conditionally renders `ApmLite`/`ApmLiteCustomLoader` with `paymentMethodType="BCI_MACH_QR"` when selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f89c06e35ea8b514a829746ced934159c1a3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->