### PR TITLE
share/24-04-26: PRIOR-420 BCI_MACH_QR checkout component

### DIFF
--- a/yuno-react/src/components/apm-lite-list/apm-lite-list.tsx
+++ b/yuno-react/src/components/apm-lite-list/apm-lite-list.tsx
@@ -11,6 +11,7 @@ export const ApmListLite: React.FC<{ customLoader: boolean }> = ({ customLoader 
   const isCARD = pmSelected === 'CARD';
   const isPSE = pmSelected === 'PSE';
   const isADDI = pmSelected === 'ADDI';
+  const isBCI_MACH_QR = pmSelected === 'BCI_MACH_QR';
 
   const ComponentApmLite = customLoader ? ApmLiteCustomLoader : ApmLite
 
@@ -39,6 +40,14 @@ export const ApmListLite: React.FC<{ customLoader: boolean }> = ({ customLoader 
         onClick={() => { setPmSelected('ADDI') }}
       />
       {isADDI && <ComponentApmLite paymentMethodType={'ADDI'} onClose={() => { setPmSelected('') }} />}
+    </div>
+    <div>
+      <RadioButton
+        checked={isBCI_MACH_QR}
+        text={'BCI_MACH_QR'}
+        onClick={() => { setPmSelected('BCI_MACH_QR') }}
+      />
+      {isBCI_MACH_QR && <ComponentApmLite paymentMethodType={'BCI_MACH_QR'} onClose={() => { setPmSelected('') }} />}
     </div>
   </Content>
 }


### PR DESCRIPTION
## Share branch for staging deploy

Cherry-picked from feat/PRIOR-420-bci-mach-qr-checkout:
- feat(PRIOR-420): add BCI_MACH_QR to APM lite checkout list

Part of PRIOR-420: BCI/MACH QR + Deeplink APM Integration (Chile)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new payment method selection path in the checkout UI; risk is mainly around downstream support for the new `paymentMethodType` and any runtime issues if it’s not handled by the APM lite component/backends.
> 
> **Overview**
> Adds `BCI_MACH_QR` to `ApmListLite` as a new radio option and conditionally renders the APM lite component with `paymentMethodType={'BCI_MACH_QR'}` when selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9626ad7458f89b6d31d4a5f97b1a2c86f18f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->