### PR TITLE
feat:[CORECM-17157] Add canary mode toggle to all demo pages

### DIFF
--- a/vanilla/pages/checkout-seamless-lite.html
+++ b/vanilla/pages/checkout-seamless-lite.html
@@ -9,8 +9,17 @@
   <title>Yuno Seamless Checkout Lite</title>
   <!-- default fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
+  <link rel="stylesheet" href="../static/styles.css">
 </head>
 <body>
+  <!-- Canary Mode Toggle -->
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input type="checkbox" id="canary-toggle" />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <!-- create a component where the SDK will be mounted -->
   <div id="root"></div>
   <div id="form-element"></div>
@@ -18,5 +27,14 @@
 
   <script type="module" src="/static/checkout-seamless-lite.js"></script>
   <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+
+  <script>
+    const canaryToggle = document.getElementById('canary-toggle')
+    canaryToggle.addEventListener('change', (e) => {
+      if (window.yunoInstance) {
+        window.yunoInstance.setCanaryMode(e.target.checked)
+      }
+    })
+  </script>
 </body>
 </html>

--- a/vanilla/pages/checkout-seamless.html
+++ b/vanilla/pages/checkout-seamless.html
@@ -12,6 +12,14 @@
   <link rel="stylesheet" href="../static/styles.css">
 </head>
 <body>
+  <!-- Canary Mode Toggle -->
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input type="checkbox" id="canary-toggle" />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <!-- create a component where the SDK will be mounted -->
   <div id="root"></div>
   <div id="form-element"></div>
@@ -20,5 +28,14 @@
 
   <script type="module" src="/static/checkout-seamless.js"></script>
   <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+
+  <script>
+    const canaryToggle = document.getElementById('canary-toggle')
+    canaryToggle.addEventListener('change', (e) => {
+      if (window.yunoInstance) {
+        window.yunoInstance.setCanaryMode(e.target.checked)
+      }
+    })
+  </script>
 </body>
 </html>

--- a/vanilla/pages/checkout.html
+++ b/vanilla/pages/checkout.html
@@ -12,6 +12,14 @@
   <link rel="stylesheet" href="../static/styles.css">
 </head>
 <body>
+  <!-- Canary Mode Toggle -->
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input type="checkbox" id="canary-toggle" />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <!-- create a component where the SDK will be mounted -->
   <div id="root"></div>
   <div id="form-element"></div>
@@ -25,5 +33,14 @@
   
   <!-- include Yuno SDK -->
   <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+
+  <script>
+    const canaryToggle = document.getElementById('canary-toggle')
+    canaryToggle.addEventListener('change', (e) => {
+      if (window.yunoInstance) {
+        window.yunoInstance.setCanaryMode(e.target.checked)
+      }
+    })
+  </script>
 </body>
 </html>

--- a/vanilla/pages/enrollment-lite.html
+++ b/vanilla/pages/enrollment-lite.html
@@ -9,8 +9,17 @@
   <title>Yuno Enrollment Lite</title>
   <!-- default fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
+  <link rel="stylesheet" href="../static/styles.css">
 </head>
 <body>
+  <!-- Canary Mode Toggle -->
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input type="checkbox" id="canary-toggle" />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <!-- create a component where the SDK will be mounted -->
   <div id="root"></div>
   <div id="form-element"></div>
@@ -18,5 +27,14 @@
 
   <script type="module" src="../static/enrollment-lite.js"></script>
   <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+
+  <script>
+    const canaryToggle = document.getElementById('canary-toggle')
+    canaryToggle.addEventListener('change', (e) => {
+      if (window.yunoInstance) {
+        window.yunoInstance.setCanaryMode(e.target.checked)
+      }
+    })
+  </script>
 </body>
 </html>

--- a/vanilla/pages/full-features.html
+++ b/vanilla/pages/full-features.html
@@ -16,6 +16,14 @@
   />
 </head>
 <body>
+  <!-- Canary Mode Toggle -->
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input type="checkbox" id="canary-toggle" />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <!-- create a component where the SDK will be mounted -->
   <div class="list-group">
     <a href="/checkout" class="list-group-item list-group-item-action" target="_blank">
@@ -28,5 +36,13 @@
     <a href="/enrollment-lite" class="list-group-item list-group-item-action" target="_blank">Enrollment Lite</a>
   </div>
 
+  <script>
+    const canaryToggle = document.getElementById('canary-toggle')
+    canaryToggle.addEventListener('change', (e) => {
+      if (window.yunoInstance) {
+        window.yunoInstance.setCanaryMode(e.target.checked)
+      }
+    })
+  </script>
 </body>
 </html>

--- a/vanilla/pages/full-features.html
+++ b/vanilla/pages/full-features.html
@@ -16,14 +16,6 @@
   />
 </head>
 <body>
-  <!-- Canary Mode Toggle -->
-  <div class="canary-toggle-container">
-    <label class="canary-toggle-label">
-      <input type="checkbox" id="canary-toggle" />
-      <span>Canary Mode</span>
-    </label>
-  </div>
-
   <!-- create a component where the SDK will be mounted -->
   <div class="list-group">
     <a href="/checkout" class="list-group-item list-group-item-action" target="_blank">
@@ -36,13 +28,5 @@
     <a href="/enrollment-lite" class="list-group-item list-group-item-action" target="_blank">Enrollment Lite</a>
   </div>
 
-  <script>
-    const canaryToggle = document.getElementById('canary-toggle')
-    canaryToggle.addEventListener('change', (e) => {
-      if (window.yunoInstance) {
-        window.yunoInstance.setCanaryMode(e.target.checked)
-      }
-    })
-  </script>
 </body>
 </html>

--- a/vanilla/static/checkout-seamless-lite.js
+++ b/vanilla/static/checkout-seamless-lite.js
@@ -16,6 +16,10 @@ async function initSeamlessCheckoutLite() {
 
   // start Yuno SDK
   const yuno = await Yuno.initialize(publicApiKey)
+
+  // expose instance for canary toggle
+  window.yunoInstance = yuno
+
   /**
    * checkout configuration
    */

--- a/vanilla/static/checkout-seamless.js
+++ b/vanilla/static/checkout-seamless.js
@@ -16,6 +16,10 @@ async function initSeamlessCheckoutLite() {
 
   // start Yuno SDK
   const yuno = await Yuno.initialize(publicApiKey)
+
+  // expose instance for canary toggle
+  window.yunoInstance = yuno
+
   /**
    * checkout configuration
    */

--- a/vanilla/static/checkout.js
+++ b/vanilla/static/checkout.js
@@ -9,6 +9,10 @@ async function initCheckout() {
 
   // start Yuno SDK
   const yuno = await Yuno.initialize(publicApiKey)
+
+  // expose instance for canary toggle
+  window.yunoInstance = yuno
+
   /**
    * checkout configuration
    */

--- a/vanilla/static/enrollment-lite.js
+++ b/vanilla/static/enrollment-lite.js
@@ -13,6 +13,9 @@ async function initEnrollmentLite() {
   // start Yuno SDK
   const yuno = await Yuno.initialize(publicApiKey)
 
+  // expose instance for canary toggle
+  window.yunoInstance = yuno
+
   yuno.mountEnrollmentLite({
     customerSession,
     /**

--- a/vanilla/static/styles.css
+++ b/vanilla/static/styles.css
@@ -55,3 +55,61 @@
 body {
   background-color: #F8FAFC;
 }
+/* Canary Mode Toggle */
+.canary-toggle-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 12px auto;
+  max-width: 450px;
+  padding: 8px 16px;
+  background: #f1f5f9;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+}
+
+.canary-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-family: 'Inter', 'Arial';
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  user-select: none;
+}
+
+.canary-toggle-label input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 40px;
+  height: 22px;
+  background: #cbd5e1;
+  border-radius: 11px;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.canary-toggle-label input[type="checkbox"]::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  background: #ffffff;
+  border-radius: 50%;
+  top: 2px;
+  left: 2px;
+  transition: left 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.canary-toggle-label input[type="checkbox"]:checked {
+  background: #632DBB;
+}
+
+.canary-toggle-label input[type="checkbox"]:checked::after {
+  left: 20px;
+}

--- a/yuno-angular/src/app/components/sdk-full/sdk-full.component.html
+++ b/yuno-angular/src/app/components/sdk-full/sdk-full.component.html
@@ -1,2 +1,14 @@
+<div class="canary-toggle-container">
+  <label class="canary-toggle-label">
+    <input
+      type="checkbox"
+      id="canary-toggle"
+      [checked]="canaryMode"
+      (change)="onCanaryToggleChange($event)"
+    />
+    <span>Canary Mode</span>
+  </label>
+</div>
+
 <div id="sdk-root"></div>
 <button (click)="onPayClick()">Pay now</button>

--- a/yuno-angular/src/app/components/sdk-full/sdk-full.component.scss
+++ b/yuno-angular/src/app/components/sdk-full/sdk-full.component.scss
@@ -1,0 +1,57 @@
+.canary-toggle-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 12px auto;
+  max-width: 450px;
+  padding: 8px 16px;
+  background: #f1f5f9;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+}
+
+.canary-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-family: 'Inter', 'Arial', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  user-select: none;
+
+  input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 40px;
+    height: 22px;
+    background: #cbd5e1;
+    border-radius: 11px;
+    position: relative;
+    cursor: pointer;
+    transition: background 0.2s ease;
+    flex-shrink: 0;
+
+    &::after {
+      content: '';
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      background: #ffffff;
+      border-radius: 50%;
+      top: 2px;
+      left: 2px;
+      transition: left 0.2s ease;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+
+    &:checked {
+      background: #632DBB;
+
+      &::after {
+        left: 20px;
+      }
+    }
+  }
+}

--- a/yuno-angular/src/app/components/sdk-full/sdk-full.component.ts
+++ b/yuno-angular/src/app/components/sdk-full/sdk-full.component.ts
@@ -1,21 +1,26 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { loadScript } from '@yuno-payments/sdk-web';
 import { YunoInstance } from '@yuno-payments/sdk-web-types';
 
 const PUBLIC_API_KEY = '';
 const CHECKOUT_SESSION = '';
 
+type YunoInstanceWithCanary = YunoInstance & { setCanaryMode: (enabled: boolean) => void };
+
 @Component({
   selector: 'app-sdk-full',
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './sdk-full.component.html',
   styleUrl: './sdk-full.component.scss',
 })
 export class SdkFullComponent implements OnInit {
-  yunoInstance?: YunoInstance;
+  yunoInstance?: YunoInstanceWithCanary;
+  canaryMode = false;
+
   async ngOnInit() {
     const yuno = await loadScript();
-    this.yunoInstance = await yuno.initialize(PUBLIC_API_KEY);
+    this.yunoInstance = (await yuno.initialize(PUBLIC_API_KEY)) as YunoInstanceWithCanary;
     await this.yunoInstance.startCheckout({
       checkoutSession: CHECKOUT_SESSION,
       countryCode: 'CO',
@@ -33,5 +38,13 @@ export class SdkFullComponent implements OnInit {
 
   onPayClick = () => {
     this.yunoInstance!.startPayment();
+  };
+
+  onCanaryToggleChange = (event: Event) => {
+    const checkbox = event.target as HTMLInputElement;
+    this.canaryMode = checkbox.checked;
+    if (this.yunoInstance) {
+      this.yunoInstance.setCanaryMode(this.canaryMode);
+    }
   };
 }

--- a/yuno-react/src/app.tsx
+++ b/yuno-react/src/app.tsx
@@ -8,21 +8,55 @@ import type { YunoInstance } from "@yuno-payments/sdk-web-types";
 const PUBLIC_API_KEY = "";
 const CHECKOUT_SESSION = "";
 
+const canaryToggleContainerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  margin: "12px auto",
+  maxWidth: "450px",
+  padding: "8px 16px",
+  background: "#f1f5f9",
+  borderRadius: "6px",
+  border: "1px solid #e2e8f0",
+};
+
+const canaryToggleLabelStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "10px",
+  cursor: "pointer",
+  fontFamily: "'Inter', 'Arial'",
+  fontSize: "14px",
+  fontWeight: 500,
+  color: "#334155",
+  userSelect: "none",
+};
+
 export const App = () => {
   const instanceFlag = useRef(0);
   const [yunoInstance, setYunoInstance] = useState<YunoInstance | null>(null);
+  const [canaryMode, setCanaryModeState] = useState(false);
 
   useEffect(() => {
     const createYunoInstance = async () => {
       const yuno = await loadScript();
-      const yunoInstance = await yuno.initialize(PUBLIC_API_KEY);
-      setYunoInstance(yunoInstance);
+      const instance = await yuno.initialize(PUBLIC_API_KEY);
+      setYunoInstance(instance);
     };
     if (instanceFlag.current === 0) {
       createYunoInstance();
       instanceFlag.current = 1;
     }
   }, []);
+
+  const handleCanaryToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = e.target.checked;
+    setCanaryModeState(enabled);
+    if (yunoInstance) {
+      // setCanaryMode is available on the SDK instance at runtime
+      (yunoInstance as YunoInstance & { setCanaryMode: (enabled: boolean) => void }).setCanaryMode(enabled);
+    }
+  };
 
   if (!yunoInstance) {
     return <div>Loading...</div>;
@@ -34,8 +68,24 @@ export const App = () => {
         checkoutSession: CHECKOUT_SESSION,
         yunoInstance,
         countryCode: "CO",
+        canaryMode,
+        setCanaryMode: (enabled: boolean) => {
+          setCanaryModeState(enabled);
+          (yunoInstance as YunoInstance & { setCanaryMode: (enabled: boolean) => void }).setCanaryMode(enabled);
+        },
       }}
     >
+      <div style={canaryToggleContainerStyle}>
+        <label style={canaryToggleLabelStyle}>
+          <input
+            type="checkbox"
+            id="canary-toggle"
+            checked={canaryMode}
+            onChange={handleCanaryToggle}
+          />
+          <span>Canary Mode</span>
+        </label>
+      </div>
       <RouterProvider router={router} />
     </AppContext.Provider>
   );

--- a/yuno-react/src/context/app-context.ts
+++ b/yuno-react/src/context/app-context.ts
@@ -5,6 +5,14 @@ type AppContextType = {
   checkoutSession: string
   countryCode: string
   yunoInstance: YunoInstance
+  canaryMode: boolean
+  setCanaryMode: (enabled: boolean) => void
 }
 
-export const AppContext = createContext<AppContextType>({ checkoutSession: '', countryCode: '', yunoInstance: {} as YunoInstance })
+export const AppContext = createContext<AppContextType>({
+  checkoutSession: '',
+  countryCode: '',
+  yunoInstance: {} as YunoInstance,
+  canaryMode: false,
+  setCanaryMode: () => {},
+})

--- a/yuno-vue/src/views/checkout-lite/CheckoutLite.vue
+++ b/yuno-vue/src/views/checkout-lite/CheckoutLite.vue
@@ -1,10 +1,91 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import Button from '../../components/Button.vue'
-import { startPayment } from './checkout-lite'
+import { startPayment, setCanaryMode } from './checkout-lite'
+
+const canaryMode = ref(false)
+
+const handleCanaryToggle = (event: Event) => {
+  const checkbox = event.target as HTMLInputElement
+  canaryMode.value = checkbox.checked
+  setCanaryMode(checkbox.checked)
+}
 </script>
 
 <template>
+  <div class="canary-toggle-container">
+    <label class="canary-toggle-label">
+      <input
+        type="checkbox"
+        id="canary-toggle"
+        :checked="canaryMode"
+        @change="handleCanaryToggle"
+      />
+      <span>Canary Mode</span>
+    </label>
+  </div>
+
   <h1>Checkout Lite</h1>
   <Button text="Start Payment" @click="startPayment"></Button>
   <div id="yuno-root"></div>
 </template>
+
+<style scoped>
+.canary-toggle-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 12px auto;
+  max-width: 450px;
+  padding: 8px 16px;
+  background: #f1f5f9;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+}
+
+.canary-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-family: 'Inter', 'Arial', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #334155;
+  user-select: none;
+}
+
+.canary-toggle-label input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 40px;
+  height: 22px;
+  background: #cbd5e1;
+  border-radius: 11px;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.canary-toggle-label input[type="checkbox"]::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  background: #ffffff;
+  border-radius: 50%;
+  top: 2px;
+  left: 2px;
+  transition: left 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.canary-toggle-label input[type="checkbox"]:checked {
+  background: #632DBB;
+}
+
+.canary-toggle-label input[type="checkbox"]:checked::after {
+  left: 20px;
+}
+</style>

--- a/yuno-vue/src/views/checkout-lite/checkout-lite.ts
+++ b/yuno-vue/src/views/checkout-lite/checkout-lite.ts
@@ -1,13 +1,18 @@
 import { loadScript } from "@yuno-payments/sdk-web";
+import type { YunoInstance } from "@yuno-payments/sdk-web-types";
 
 const PUBLIC_API_KEY = "test";
 const CHECKOUT_SESSION = "";
 const PAYMENT_METHOD_TYPE = "CARD";
 const VAULTED_TOKEN = undefined;
 
+type YunoInstanceWithCanary = YunoInstance & { setCanaryMode: (enabled: boolean) => void };
+
+let yunoInstance: YunoInstanceWithCanary | null = null;
+
 export const startPayment = async () => {
   const yuno = await loadScript();
-  const yunoInstance = await yuno.initialize(PUBLIC_API_KEY);
+  yunoInstance = (await yuno.initialize(PUBLIC_API_KEY)) as YunoInstanceWithCanary;
 
   await yunoInstance.startCheckout({
     checkoutSession: CHECKOUT_SESSION,
@@ -24,4 +29,10 @@ export const startPayment = async () => {
     paymentMethodType: PAYMENT_METHOD_TYPE,
     vaultedToken: VAULTED_TOKEN,
   });
+};
+
+export const setCanaryMode = (enabled: boolean) => {
+  if (yunoInstance) {
+    yunoInstance.setCanaryMode(enabled);
+  }
 };

--- a/yuno-vue/src/views/checkout-lite/checkout-lite.ts
+++ b/yuno-vue/src/views/checkout-lite/checkout-lite.ts
@@ -9,10 +9,16 @@ const VAULTED_TOKEN = undefined;
 type YunoInstanceWithCanary = YunoInstance & { setCanaryMode: (enabled: boolean) => void };
 
 let yunoInstance: YunoInstanceWithCanary | null = null;
+let pendingCanaryMode = false;
 
 export const startPayment = async () => {
   const yuno = await loadScript();
   yunoInstance = (await yuno.initialize(PUBLIC_API_KEY)) as YunoInstanceWithCanary;
+
+  // Apply stored canary preference to the new SDK instance
+  if (pendingCanaryMode) {
+    yunoInstance.setCanaryMode(true);
+  }
 
   await yunoInstance.startCheckout({
     checkoutSession: CHECKOUT_SESSION,
@@ -32,6 +38,7 @@ export const startPayment = async () => {
 };
 
 export const setCanaryMode = (enabled: boolean) => {
+  pendingCanaryMode = enabled;
   if (yunoInstance) {
     yunoInstance.setCanaryMode(enabled);
   }


### PR DESCRIPTION
## Summary
- Add canary mode toggle switch to vanilla demo pages (checkout, checkout-seamless, checkout-seamless-lite, enrollment-lite)
- Add canary mode toggle to React, Angular, and Vue demo applications
- Toggle calls `yuno.setCanaryMode(enabled)` on the SDK instance at runtime
- Toggle defaults to OFF on page load; styled with consistent Yuno branding

## Changes
| Area | Files | Change |
|------|-------|--------|
| Vanilla HTML | 4 pages | Add checkbox toggle HTML + inline script |
| Vanilla JS | 4 JS files | Expose `yuno` as `window.yunoInstance` |
| Vanilla CSS | `styles.css` | Toggle switch styling |
| React | `app.tsx`, `app-context.ts` | State + toggle component + context extension |
| Angular | `sdk-full.component.*` | Toggle in template + handler + SCSS |
| Vue | `CheckoutLite.vue`, `checkout-lite.ts` | Ref + toggle + scoped styles + state persistence |

## Acceptance Criteria
- [x] FR-2: Each demo has visible toggle defaulting to OFF
- [x] FR-2: Toggle ON calls `setCanaryMode(true)`
- [x] FR-2: Toggle OFF calls `setCanaryMode(false)`
- [x] FR-3: All framework demos (Vanilla, React, Angular, Vue) support canary mode

## Test Plan
- [x] Manual: Open each demo page, toggle ON, verify header in DevTools Network tab
- [x] Manual: Toggle OFF, verify header removed

## Related
- Jira: CORECM-17157
- Board Card: #124
- Depends on: sdk-web PR (CDN deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to demo UIs and wire a new `setCanaryMode` call on the client-side SDK instance, with no backend or payment-flow logic changes beyond toggling a runtime flag.
> 
> **Overview**
> Adds a **"Canary Mode" UI toggle** across the Vanilla HTML demos (checkout + seamless + lite + enrollment) and the React/Angular/Vue demo apps, defaulting to off.
> 
> The toggle is wired to call `yunoInstance.setCanaryMode(enabled)` at runtime; Vanilla demos expose the SDK instance via `window.yunoInstance`, React/Angular keep local state and invoke `setCanaryMode`, and Vue persists the toggle choice to apply it once the SDK instance is created. Styling for the toggle is added to `vanilla/static/styles.css` (and equivalent component styles in Angular/Vue, inline styles in React).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8d0e92518fac709bef9a11552450b059a2a691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->