### PR TITLE
feat:[NO-CODE] add white-label-proxy-server to test sdk-web PR #2086

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuno-sdk-web",
-  "version": "1.5.0",
+  "version": "1.9.0",
   "description": "Demo app to show how to use Yuno's web SDK",
   "main": "index.js",
   "scripts": {

--- a/white-label-proxy-server/.env.example
+++ b/white-label-proxy-server/.env.example
@@ -1,0 +1,83 @@
+# =============================================================================
+# white-label-proxy-server — environment configuration
+# =============================================================================
+# Copy this file to `.env` and adjust per environment. Yuno hostnames follow
+# a `<service>[.<env>].y.uno` pattern:
+#   production : <service>.y.uno
+#   staging    : <service>.staging.y.uno
+#   dev        : <service>.dev.y.uno
+# The API surface is the exception — it uses a `api[-<env>].y.uno` prefix:
+#   production : api.y.uno
+#   staging    : api-staging.y.uno
+#   dev        : api-dev.y.uno
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# SDK_UPSTREAM — main SDK bundle (loaded by partner pages as /v<semver>/main.js)
+# Point at wherever the PR #2086 build is hosted.
+#   production : https://sdk-web.y.uno
+#   staging    : https://sdk-web.staging.y.uno
+#   dev        : https://sdk-web.dev.y.uno
+# -----------------------------------------------------------------------------
+SDK_UPSTREAM=https://sdk-web.y.uno
+
+# -----------------------------------------------------------------------------
+# SDK_CARD_UPSTREAM — card-form / secure-fields micro-app
+# Published independently of the main SDK. Routes:
+#   /v<semver>/pages/*    (e.g. /v1.84.1/pages/secured-fields.html)
+#   /v<semver>/assets/*
+# Defaults to SDK_UPSTREAM when unset.
+#   production : https://sdk-web-card.y.uno
+#   staging    : https://sdk-web-card.staging.y.uno
+#   dev        : https://sdk-web-card.dev.y.uno
+# -----------------------------------------------------------------------------
+SDK_CARD_UPSTREAM=https://sdk-web-card.y.uno
+
+# -----------------------------------------------------------------------------
+# SDK_3DS_UPSTREAM — 3DS challenge / redirect / session-id micro-app. Routes:
+#   /challenge.html, /redirect.html, /session-id.html
+#   /assets/(challenge|redirect|session-id|validate-url)*
+# Defaults to SDK_UPSTREAM when unset.
+#   production : https://sdk-3ds.y.uno
+#   staging    : https://sdk-3ds.staging.y.uno
+#   dev        : https://sdk-3ds.dev.y.uno
+# -----------------------------------------------------------------------------
+SDK_3DS_UPSTREAM=https://sdk-3ds.y.uno
+
+# -----------------------------------------------------------------------------
+# BACKEND_URL — SDK API surface (/v1/*, /v2/*, see public-sdk.ts in sdk-web-core).
+# Stands in for `api.y.uno` while the SDK is loaded from this white-label origin.
+#   production    : https://api.y.uno
+#   staging       : https://api-staging.y.uno
+#   dev           : https://api-dev.y.uno
+#   local backend : http://localhost:8080  (run `cd .. && npm run start:dev`)
+# -----------------------------------------------------------------------------
+BACKEND_URL=https://api.y.uno
+
+# -----------------------------------------------------------------------------
+# BACKEND_WS_URL — WebSocket upstream for the checkout notification service.
+# Used for `Upgrade` requests on:
+#   /checkout-websocket-notification-ms/ws/payment
+#   /checkout-websocket-notification-ms/ws/enrollment
+# Note: the WS hostname has NO `api-` prefix — it's `<env>.y.uno` directly.
+# Use https:// for wss:// or http:// for ws:// — http-proxy negotiates the WS
+# scheme from the target's scheme. Defaults to BACKEND_URL when unset.
+#   production : https://y.uno
+#   staging    : https://staging.y.uno
+#   dev        : https://dev.y.uno
+# -----------------------------------------------------------------------------
+BACKEND_WS_URL=https://y.uno
+
+# -----------------------------------------------------------------------------
+# PORT — this proxy's listen port. Deliberately different from 8080 so the SDK
+# is loaded from a non-Yuno-branded origin during testing.
+# -----------------------------------------------------------------------------
+PORT=9090
+
+# -----------------------------------------------------------------------------
+# SDK_MAIN_JS — optional override for the main.js path injected into pages.
+# By default the proxy reads `latest.version` from <SDK_UPSTREAM>/versions.json
+# (e.g. /v1.7.4/main.js) and falls back to /v1.7/main.js if that fails.
+# Set this to pin a specific SDK version regardless of what `latest` reports.
+# -----------------------------------------------------------------------------
+SDK_MAIN_JS=/v1.7.4/main.js

--- a/white-label-proxy-server/.gitignore
+++ b/white-label-proxy-server/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+*.log
+.DS_Store

--- a/white-label-proxy-server/CLAUDE.md
+++ b/white-label-proxy-server/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md — white-label-proxy-server
+
+## Purpose
+
+A standalone Express proxy that hosts a minimal landing page on `localhost:9090` and forwards SDK assets, API
+calls, and WebSocket upgrades to configurable upstreams. Partner test pages (your own or another subproject)
+point their `<script src>` at this origin so the SDK runs against a non-Yuno host. Built specifically to
+exercise the white-label rename in [sdk-web PR #2086](https://github.com/yuno-payments/sdk-web/pull/2086):
+
+- `window.SdkPayments` (new) vs `window.Yuno` (legacy alias)
+- `sdk-payments-ready` event vs `yuno-sdk-ready`
+- No `yuno-*` / `Yuno-*` DOM tokens leaking to the merchant page
+
+This subproject is **independent** of the rest of `yuno-sdk-web` — own `package.json`, own lockfile, own
+dependencies. Do not try to share modules with the parent.
+
+## Architecture
+
+Single file: `server.js`. Routes are registered in this order (order matters):
+
+1. JSON body parser + permissive CORS middleware (echoes caller origin, strips upstream CORS).
+2. Local routes: `/` (landing), `/static/*`, `/whitelabel-info`.
+3. **Backend pass-through**: `app.all('/v1/*' | '/v2/*', forwardToBackend)` → `BACKEND_URL`.
+   Uses `node-fetch`; re-serializes the body (since `express.json()` consumed it).
+4. **SDK upstream catch-all** (GET/HEAD): `proxyToUpstream` picks one of three upstreams:
+   - `SDK_3DS_UPSTREAM` for `/challenge.html`, `/redirect.html`, `/session-id.html`, and
+     `/assets/(challenge|redirect|session-id|validate-url)*`.
+   - `SDK_CARD_UPSTREAM` for `/v<semver>/pages/*` and `/v<semver>/assets/*`.
+   - `SDK_UPSTREAM` otherwise.
+   For the main SDK upstream, the version segment is normalized to whatever `versions.json` says is `latest`,
+   so partners can request any `/v<x>/main.js` and still hit the published build.
+5. 404 fallback.
+6. WebSocket upgrades on the underlying `http.Server` (Express middleware never sees `Upgrade`).
+   Uses `http-proxy`. `/checkout-websocket-notification-ms/ws/{payment,enrollment}` → `BACKEND_WS_URL`;
+   everything else follows the same SDK/card/3DS split as HTTP.
+
+The injected `main.js` path is resolved once at boot:
+- If `process.env.SDK_MAIN_JS` is set, use it.
+- Else fetch `<SDK_UPSTREAM>/versions.json` and use `latest.version` (`/v<x.y.z>/main.js`).
+- Else fall back to `/v1.7/main.js`.
+
+Template tag `__SDK_MAIN_JS__` in `pages/index.html` is replaced server-side per request, in case a future
+landing page wants to embed the resolved main.js path. There are no checkout test pages here anymore — point
+your own partner pages (or another subproject in this repo) at `http://localhost:9090` to exercise the SDK
+against a non-Yuno origin.
+
+## Running
+
+```bash
+cp .env.example .env
+npm install
+npm start    # → http://localhost:9090
+```
+
+`BACKEND_URL` defaults to `http://localhost:8080`, so for the default config also run the root server
+(`cd .. && npm run start:dev`) so `/v1/*` and `/v2/*` succeed.
+
+## Things to watch when editing
+
+- **Route order matters.** The SDK upstream catch-all is `app.use((req, res, next) => ...)` registered last;
+  anything you add after it will be unreachable unless you guard the catch-all.
+- **CORS headers must come from this server, not upstream.** The middleware in `server.js:69` is what makes
+  credentialed cross-origin requests work from the merchant page. The upstream proxy strips
+  `access-control-*` from upstream responses (`server.js:166-170`) for the same reason — don't pass them through.
+- **`HOP_BY_HOP` headers** (`server.js:130-141`) are filtered both ways. Don't add `content-length` to a manual
+  copy without re-stripping it — node-fetch sets it itself.
+- **The version normalizer** only touches `SDK_UPSTREAM` paths. Card and 3DS upstreams handle their own
+  versioning (or don't version at all). If you broaden it, make sure card paths still resolve.
+- **WebSocket auth** is whatever `http-proxy` sees in the upstream-bound request headers. Do not strip
+  `cookie` or `authorization` from WS upgrades.
+- **`.env` is gitignored**, `.env.example` is the source of truth for available knobs. Keep them in sync.
+
+## Out of scope for this server
+
+- No build step — plain Node + ES modules in the browser. Don't introduce a bundler.
+- No tests yet. If you add some, they should hit real upstream HTML/JS responses (mocking the proxy defeats its
+  purpose).
+- Don't add backwards-compat shims for `window.Yuno` here — that's the SDK's responsibility (and it already
+  exposes it as a legacy alias).

--- a/white-label-proxy-server/README.md
+++ b/white-label-proxy-server/README.md
@@ -1,0 +1,84 @@
+# white-label-proxy-server
+
+Test harness for [sdk-web PR #2086](https://github.com/yuno-payments/sdk-web/pull/2086) — the white-label rename
+(`window.SdkPayments`, `sdk-payments-ready` event, no `yuno-*` DOM tokens leaked to the merchant page).
+
+The server hosts a minimal landing page on a **non-Yuno origin** (`localhost:9090`) and transparently proxies all
+SDK asset, API, and WebSocket traffic upstream. Partner test pages — your own or another subproject — point their
+`<script src>` at this origin so the SDK loads from `localhost:9090` (no `*.y.uno` hostname), which is what
+exercises the white-label code paths end-to-end.
+
+## What it does
+
+| Request                                                | Routed to                              |
+| ------------------------------------------------------ | -------------------------------------- |
+| `/`                                                    | Landing page (`pages/index.html`)      |
+| `/static/*`                                            | Local assets (`static/*`)              |
+| `/whitelabel-info`                                     | JSON describing current upstream config |
+| `/v1/*`, `/v2/*` (HTTP + WS)                           | `BACKEND_URL` / `BACKEND_WS_URL`       |
+| `/challenge.html`, `/redirect.html`, `/session-id.html`, `/assets/(challenge\|redirect\|session-id\|validate-url)*` | `SDK_3DS_UPSTREAM` |
+| `/v<semver>/pages/*`, `/v<semver>/assets/*`            | `SDK_CARD_UPSTREAM`                    |
+| Everything else (GET/HEAD)                             | `SDK_UPSTREAM`                         |
+
+Additional behaviour worth knowing:
+
+- The injected `main.js` path is resolved at boot from `<SDK_UPSTREAM>/versions.json` (`latest.version`).
+  Override with `SDK_MAIN_JS=/v1.7/main.js` in `.env`.
+- Partners can reference any version (e.g. `/v1.100/main.js`); requests are normalized to the version the
+  upstream actually publishes.
+- Permissive CORS — caller origin is echoed back, upstream CORS headers are stripped so they can't override.
+
+## Setup
+
+```bash
+cp .env.example .env       # then edit upstream URLs if needed
+npm install
+npm start                  # listens on :9090
+```
+
+For the default backend (`BACKEND_URL=http://localhost:8080`), also run the root server so `/v1/*` and `/v2/*`
+calls succeed:
+
+```bash
+cd .. && npm run start:dev
+```
+
+Then open http://localhost:9090/ for the landing page (shows current proxy config). Point your own
+partner test pages at `http://localhost:9090` — e.g. load the SDK via
+`<script src="http://localhost:9090/v1.7/main.js">` — and the proxy will fetch it from `SDK_UPSTREAM`
+on your behalf so the SDK runs against a non-Yuno origin.
+
+## Environment variables
+
+Copy `.env.example` to `.env` and adjust. Yuno hostnames follow two conventions:
+
+- **SDK services** use `<service>[.<env>].y.uno` — e.g. `sdk-web.y.uno`, `sdk-web.staging.y.uno`, `sdk-web.dev.y.uno`.
+- **API surface** uses an `api[-<env>].y.uno` prefix — e.g. `api.y.uno`, `api-staging.y.uno`, `api-dev.y.uno`.
+- **WebSocket service** has NO `api-` prefix — it's `<env>.y.uno` directly (`y.uno`, `staging.y.uno`, `dev.y.uno`).
+
+| Var                  | Purpose                                       | Production                       | Staging                                  | Dev                                  |
+| -------------------- | --------------------------------------------- | -------------------------------- | ---------------------------------------- | ------------------------------------ |
+| `PORT`               | Proxy listen port                             | `9090`                           | `9090`                                   | `9090`                               |
+| `SDK_UPSTREAM`       | Main SDK bundle                               | `https://sdk-web.y.uno`          | `https://sdk-web.staging.y.uno`          | `https://sdk-web.dev.y.uno`          |
+| `SDK_CARD_UPSTREAM`  | Card-form / secure-fields micro-app           | `https://sdk-web-card.y.uno`     | `https://sdk-web-card.staging.y.uno`     | `https://sdk-web-card.dev.y.uno`     |
+| `SDK_3DS_UPSTREAM`   | 3DS challenge / redirect / session-id pages   | `https://sdk-3ds.y.uno`          | `https://sdk-3ds.staging.y.uno`          | `https://sdk-3ds.dev.y.uno`          |
+| `BACKEND_URL`        | SDK API (`/v1/*`, `/v2/*`)                    | `https://api.y.uno`              | `https://api-staging.y.uno`              | `https://api-dev.y.uno`              |
+| `BACKEND_WS_URL`     | WebSocket upgrades                            | `https://y.uno`                  | `https://staging.y.uno`                  | `https://dev.y.uno`                  |
+| `SDK_MAIN_JS`        | Pin a specific SDK version                    | `/v1.7.4/main.js`                | `/v1.7.4/main.js`                        | `/v1.7.4/main.js`                    |
+
+Defaults:
+
+- `SDK_CARD_UPSTREAM`, `SDK_3DS_UPSTREAM`, `BACKEND_WS_URL` fall back to `SDK_UPSTREAM` / `BACKEND_URL` when unset.
+- `SDK_MAIN_JS` is auto-resolved from `<SDK_UPSTREAM>/versions.json` (`latest.version`), falling back to `/v1.7/main.js`.
+- `BACKEND_URL` can also point at a local backend (`http://localhost:8080`) — run `cd .. && npm run start:dev`.
+
+## Layout
+
+```
+white-label-proxy-server/
+├── server.js              # Express + http-proxy server (single file)
+├── pages/                 # Landing page (index.html)
+├── static/                # Page JS/CSS (api.js, styles.css)
+├── .env.example
+└── package.json
+```

--- a/white-label-proxy-server/package-lock.json
+++ b/white-label-proxy-server/package-lock.json
@@ -1,0 +1,945 @@
+{
+  "name": "white-label-proxy-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "white-label-proxy-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.0.1",
+        "express": "^4.21.2",
+        "http-proxy": "^1.18.1",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/white-label-proxy-server/package.json
+++ b/white-label-proxy-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "white-label-proxy-server",
+  "version": "1.0.0",
+  "description": "Proxy server to test sdk-web PR #2086 — serves the SDK from a non-Yuno host so the white-label rename (window.SdkPayments / sdk-payments-ready / sdk-payments-* DOM tokens) can be exercised end-to-end.",
+  "private": true,
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "start:dev": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.0.1",
+    "express": "^4.21.2",
+    "http-proxy": "^1.18.1",
+    "node-fetch": "^2.6.7"
+  }
+}

--- a/white-label-proxy-server/pages/index.html
+++ b/white-label-proxy-server/pages/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Acme Pay — White-Label Proxy</title>
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <main>
+    <header class="partner">
+      <span class="badge">Partner</span>
+      <strong>Acme Pay</strong>
+    </header>
+
+    <h1>White-label SDK proxy</h1>
+    <p>
+      The SDK is loaded from <code>this</code> origin (no <code>*.y.uno</code>
+      hostname). Point your partner pages at <code>http://localhost:9090</code>
+      to verify PR
+      <a href="https://github.com/yuno-payments/sdk-web/pull/2086" target="_blank" rel="noreferrer">sdk-web#2086</a>:
+      <code>window.SdkPayments</code>, <code>sdk-payments-ready</code> event, and
+      no <code>yuno-*</code> DOM tokens leaked to the merchant page.
+    </p>
+
+    <section class="wl-panel">
+      <h2>Proxy configuration</h2>
+      <pre id="proxy-info">loading…</pre>
+      <p class="proxy-info">
+        Set <code>SDK_UPSTREAM</code> in <code>.env</code> to wherever the
+        PR #2086 build is hosted. Every SDK asset request below is forwarded
+        from this origin to that upstream — partner pages never talk to a
+        <code>*.y.uno</code> host directly.
+      </p>
+    </section>
+  </main>
+
+  <script type="module">
+    import { getProxyInfo } from '/static/api.js'
+    const el = document.getElementById('proxy-info')
+    try {
+      el.textContent = JSON.stringify(await getProxyInfo(), null, 2)
+    } catch (e) {
+      el.textContent = `failed to load: ${e.message}`
+    }
+  </script>
+</body>
+</html>

--- a/white-label-proxy-server/server.js
+++ b/white-label-proxy-server/server.js
@@ -1,0 +1,289 @@
+const express = require('express')
+const path = require('path')
+const fs = require('fs')
+const fetch = require('node-fetch')
+const httpProxy = require('http-proxy')
+
+require('dotenv').config()
+
+const PORT = Number(process.env.PORT) || 9090
+const BACKEND_URL = (process.env.BACKEND_URL || 'http://localhost:8080').replace(/\/$/, '')
+const BACKEND_WS_URL = (process.env.BACKEND_WS_URL || BACKEND_URL).replace(/\/$/, '')
+const SDK_UPSTREAM = (process.env.SDK_UPSTREAM || 'https://sdk-web.y.uno').replace(/\/$/, '')
+// Card-form / secure-fields micro-app is published independently of the main
+// SDK bundle and lives under /v<semver>/pages/* and /v<semver>/assets/*. When
+// SDK_CARD_UPSTREAM is set, those requests are routed there instead.
+const SDK_CARD_UPSTREAM = (process.env.SDK_CARD_UPSTREAM || SDK_UPSTREAM).replace(/\/$/, '')
+// 3DS micro-app (challenge / redirect / session-id pages) is also published
+// separately. Defaults to SDK_UPSTREAM when unset.
+const SDK_3DS_UPSTREAM = (process.env.SDK_3DS_UPSTREAM || SDK_UPSTREAM).replace(/\/$/, '')
+
+// Matches /v<version>/(pages|assets)/... where <version> is any dot-separated
+// number sequence (v1.7, v1.84.1, v2.0.0-rc.1, …).
+const CARD_ASSET_RE = /^\/v[\d.]+(?:-[\w.]+)?\/(?:pages|assets)\//
+// Matches /v<version>/<rest> generally (used for version normalization).
+const SDK_VERSION_RE = /^\/v[\d.]+(?:-[\w.]+)?\//
+// 3DS top-level pages routed to SDK_3DS_UPSTREAM.
+const SDK_3DS_PATHS = new Set(['/challenge.html', '/redirect.html', '/session-id.html'])
+// 3DS hashed assets emitted by the build live under /assets/ with these
+// prefixes (e.g. /assets/challenge-DeAdBeEf.js, /assets/validate-url.js).
+const SDK_3DS_ASSET_RE = /^\/assets\/(?:challenge|redirect|session-id|validate-url)/
+
+function pickSdkUpstream(reqPath) {
+  if (SDK_3DS_PATHS.has(reqPath) || SDK_3DS_ASSET_RE.test(reqPath)) return SDK_3DS_UPSTREAM
+  if (CARD_ASSET_RE.test(reqPath)) return SDK_CARD_UPSTREAM
+  return SDK_UPSTREAM
+}
+
+function getResolvedSdkVersion() {
+  const m = sdkMainJsPath.match(/^\/v([\d.]+(?:-[\w.]+)?)\//)
+  return m ? m[1] : null
+}
+
+// Normalize the version segment of an SDK upstream path so partners can
+// reference any version they like (e.g. /v1.100/main.js) and still get the
+// build the upstream actually publishes (e.g. /v1.7/main.js). Card paths are
+// left alone since the card upstream has its own versioning.
+function normalizeSdkPath(originalUrl) {
+  if (CARD_ASSET_RE.test(originalUrl)) return originalUrl
+  if (!SDK_VERSION_RE.test(originalUrl)) return originalUrl
+  const resolved = getResolvedSdkVersion()
+  if (!resolved) return originalUrl
+  return originalUrl.replace(SDK_VERSION_RE, `/v${resolved}/`)
+}
+
+// Resolved at boot. SDK_MAIN_JS env override wins; otherwise we fetch the
+// upstream's versions.json and use `latest.version`. Falls back to /v1.7.
+let sdkMainJsPath = process.env.SDK_MAIN_JS || '/v1.7/main.js'
+
+const app = express()
+
+const pagesDir = path.join(__dirname, 'pages')
+const staticDir = path.join(__dirname, 'static')
+
+app.use(express.json({ limit: '5mb' }))
+
+// Permissive CORS: echo the caller's origin (so credentialed requests work)
+// and short-circuit preflights. Upstream CORS headers are filtered out below
+// so they can't override these.
+app.use((req, res, next) => {
+  const origin = req.headers.origin
+  if (origin) {
+    res.set('access-control-allow-origin', origin)
+    res.set('access-control-allow-credentials', 'true')
+    res.set('vary', 'origin')
+  } else {
+    res.set('access-control-allow-origin', '*')
+  }
+  res.set('access-control-allow-methods', req.headers['access-control-request-method'] || 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS')
+  res.set('access-control-allow-headers', req.headers['access-control-request-headers'] || '*')
+  res.set('access-control-expose-headers', '*')
+  res.set('access-control-max-age', '86400')
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return
+  }
+  next()
+})
+
+// ---- partner site (test pages) -------------------------------------------
+
+const htmlCache = new Map()
+function sendPage(name, res) {
+  let html = htmlCache.get(name)
+  if (!html) {
+    html = fs.readFileSync(path.join(pagesDir, name), 'utf8')
+    htmlCache.set(name, html)
+  }
+  res.set('content-type', 'text/html; charset=utf-8')
+  res.send(html.replace(/__SDK_MAIN_JS__/g, sdkMainJsPath))
+}
+
+app.get('/', (_req, res) => sendPage('index.html', res))
+app.use('/static', express.static(staticDir))
+
+app.get('/whitelabel-info', (_req, res) => {
+  res.json({
+    proxyPort: PORT,
+    backend: BACKEND_URL,
+    sdkUpstream: SDK_UPSTREAM,
+    sdkCardUpstream: SDK_CARD_UPSTREAM,
+    sdk3dsUpstream: SDK_3DS_UPSTREAM,
+    sdkMainJsPath,
+  })
+})
+
+// ---- SDK API pass-through (to BACKEND_URL) -------------------------------
+//
+// Every path the SDK calls in sdk-web-core/src/api/public-sdk/public-sdk.ts
+// lives under /v1/* or /v2/*. Forwarding these lets BACKEND_URL act as a
+// stand-in for `api.y.uno` while the SDK is hosted under this white-label
+// origin.
+
+app.all('/v1/*', forwardToBackend)
+app.all('/v2/*', forwardToBackend)
+
+// Headers that must not be copied across a hop (RFC 7230 §6.1) plus a few we
+// recompute or that node-fetch sets itself.
+const HOP_BY_HOP = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'content-length',
+])
+
+function pickRequestHeaders(req) {
+  const out = {}
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (!HOP_BY_HOP.has(k.toLowerCase())) out[k] = v
+  }
+  return out
+}
+
+async function forwardToBackend(req, res) {
+  const targetUrl = `${BACKEND_URL}${req.originalUrl}`
+  try {
+    const headers = pickRequestHeaders(req)
+    const init = { method: req.method, headers }
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      // express.json() consumed the original body; re-serialize. SDK API and
+      // demo backend both speak JSON, so this is fine.
+      const hasBody = req.body && Object.keys(req.body).length > 0
+      init.body = hasBody ? JSON.stringify(req.body) : undefined
+      if (hasBody && !headers['content-type']) headers['content-type'] = 'application/json'
+    }
+    const upstream = await fetch(targetUrl, init)
+    res.status(upstream.status)
+    for (const [k, v] of upstream.headers.entries()) {
+      const lk = k.toLowerCase()
+      if (HOP_BY_HOP.has(lk)) continue
+      if (lk.startsWith('access-control-')) continue
+      res.set(k, v)
+    }
+    res.set('x-white-label-proxy', 'backend')
+    const body = await upstream.text()
+    res.send(body)
+  } catch (err) {
+    console.error(`[backend-proxy] ${req.method} ${targetUrl} →`, err.message)
+    res.status(502).json({ error: 'backend_unreachable', target: targetUrl, detail: err.message })
+  }
+}
+
+// ---- SDK assets (white-label host) ---------------------------------------
+//
+// The whole point of the proxy: the SDK is loaded from THIS origin, not from
+// sdk-web.y.uno. Every GET that didn't match a route above is transparently
+// forwarded to SDK_UPSTREAM. Registered last so it doesn't shadow / or /static.
+
+app.use((req, res, next) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return next()
+  proxyToUpstream(req, res, next)
+})
+
+function labelForUpstream(upstreamBase) {
+  if (upstreamBase === SDK_3DS_UPSTREAM && SDK_3DS_UPSTREAM !== SDK_UPSTREAM) return '3ds'
+  if (upstreamBase === SDK_CARD_UPSTREAM && SDK_CARD_UPSTREAM !== SDK_UPSTREAM) return 'card'
+  return 'sdk'
+}
+
+async function proxyToUpstream(req, res, next) {
+  const upstreamBase = pickSdkUpstream(req.path)
+  const upstreamLabel = labelForUpstream(upstreamBase)
+  const targetPath = upstreamLabel === 'sdk' ? normalizeSdkPath(req.originalUrl) : req.originalUrl
+  const targetUrl = `${upstreamBase}${targetPath}`
+  if (targetPath !== req.originalUrl) {
+    console.log(`[${upstreamLabel}-proxy] rewrote ${req.originalUrl} → ${targetPath}`)
+  }
+  try {
+    const upstream = await fetch(targetUrl, {
+      method: 'GET',
+      redirect: 'follow',
+      headers: {
+        accept: req.headers.accept || '*/*',
+        'user-agent': req.headers['user-agent'] || 'white-label-proxy',
+      },
+    })
+    if (upstream.status === 404) return next()
+    res.status(upstream.status)
+    const passthroughHeaders = ['content-type', 'cache-control', 'etag', 'last-modified']
+    for (const h of passthroughHeaders) {
+      const v = upstream.headers.get(h)
+      if (v) res.set(h, v)
+    }
+    res.set('x-white-label-proxy', upstreamLabel)
+    upstream.body.pipe(res)
+  } catch (err) {
+    console.error(`[${upstreamLabel}-proxy] GET ${targetUrl} →`, err.message)
+    res.status(502).send(`SDK upstream error: ${err.message}`)
+  }
+}
+
+app.use((_req, res) => res.status(404).send('Not found'))
+
+// ---- WebSocket upgrades --------------------------------------------------
+//
+// Express middleware never sees `Upgrade` requests; they have to be handled
+// on the underlying http.Server. Backend WS (`/v1/*`, `/v2/*`) goes to
+// BACKEND_URL; everything else follows the same SDK/card split as HTTP.
+
+const wsProxy = httpProxy.createProxyServer({ changeOrigin: true, ws: true })
+
+wsProxy.on('error', (err, req, socket) => {
+  console.error(`[ws-proxy] ${req && req.url} →`, err.message)
+  if (socket && !socket.destroyed) socket.destroy()
+})
+
+const BACKEND_WS_PATHS = [
+  '/checkout-websocket-notification-ms/ws/payment',
+  '/checkout-websocket-notification-ms/ws/enrollment',
+]
+
+function pickWsTarget(reqUrl) {
+  const pathname = reqUrl.split('?')[0]
+  if (BACKEND_WS_PATHS.includes(pathname)) return BACKEND_WS_URL
+  return pickSdkUpstream(reqUrl)
+}
+
+// ---- boot -----------------------------------------------------------------
+
+async function detectSdkMainJs() {
+  if (process.env.SDK_MAIN_JS) return
+  try {
+    const r = await fetch(`${SDK_UPSTREAM}/versions.json`, { timeout: 5000 })
+    if (!r.ok) return
+    const v = (await r.json())?.latest?.version
+    if (v) sdkMainJsPath = `/v${v}/main.js`
+  } catch (e) {
+    console.warn(`[sdk-version] could not read ${SDK_UPSTREAM}/versions.json: ${e.message}`)
+  }
+}
+
+detectSdkMainJs().finally(() => {
+  const server = app.listen(PORT, () => {
+    console.log('================================================================')
+    console.log(' white-label-proxy-server')
+    console.log('----------------------------------------------------------------')
+    console.log(` Listening on    : http://localhost:${PORT}`)
+    console.log(` SDK upstream    : ${SDK_UPSTREAM}`)
+    console.log(` SDK card upstream: ${SDK_CARD_UPSTREAM}${SDK_CARD_UPSTREAM === SDK_UPSTREAM ? ' (same as SDK upstream)' : ''}`)
+    console.log(` SDK 3DS upstream: ${SDK_3DS_UPSTREAM}${SDK_3DS_UPSTREAM === SDK_UPSTREAM ? ' (same as SDK upstream)' : ''}`)
+    console.log(` SDK main.js     : ${sdkMainJsPath}`)
+    console.log(` Backend (API)   : ${BACKEND_URL}`)
+    console.log(` Backend (WS)    : ${BACKEND_WS_URL}${BACKEND_WS_URL === BACKEND_URL ? ' (same as backend)' : ''}`)
+    console.log('----------------------------------------------------------------')
+    console.log(' Make sure the main yuno-sdk-web server is running on 8080')
+    console.log(' (cd .. && npm run start:dev) so backend calls succeed.')
+    console.log('================================================================')
+  })
+
+  server.on('upgrade', (req, socket, head) => {
+    const target = pickWsTarget(req.url)
+    wsProxy.ws(req, socket, head, { target })
+  })
+})

--- a/white-label-proxy-server/static/api.js
+++ b/white-label-proxy-server/static/api.js
@@ -1,0 +1,8 @@
+// All requests go through the white-label proxy (this same origin), which
+// forwards them to the backend server on port 8080. The browser never talks
+// to a *.y.uno host directly — that is the whole point of the white-label
+// setup.
+
+export async function getProxyInfo() {
+  return fetch('/whitelabel-info').then((r) => r.json())
+}

--- a/white-label-proxy-server/static/styles.css
+++ b/white-label-proxy-server/static/styles.css
@@ -1,0 +1,89 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Inter, sans-serif;
+  margin: 0;
+  padding: 24px;
+  background: #f5f6f8;
+  color: #1f2329;
+}
+
+header.partner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  background: #1b6ef3;
+  color: #fff;
+  border-radius: 10px;
+  margin-bottom: 24px;
+}
+
+header.partner .badge {
+  background: rgba(255, 255, 255, 0.18);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+main {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+#root, #form-element, #action-form-element {
+  background: #fff;
+  border-radius: 10px;
+  margin-bottom: 16px;
+}
+
+button {
+  background: #1b6ef3;
+  color: #fff;
+  border: 0;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wl-panel {
+  background: #fff;
+  border: 1px solid #e3e6eb;
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin-top: 24px;
+}
+
+.wl-panel h2 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #565b66;
+}
+
+#wl-status { list-style: none; padding: 0; margin: 0; font-size: 13px; }
+#wl-status li { padding: 6px 0; border-bottom: 1px solid #f0f1f4; }
+#wl-status li.ok { color: #1f7a3a; }
+#wl-status li.fail { color: #c4283a; }
+#wl-status pre {
+  background: #f7f8fa;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 6px 0 0;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #1f2329;
+}
+
+.proxy-info {
+  font-size: 12px;
+  color: #565b66;
+  margin-top: 8px;
+}
+.proxy-info code { background: #f0f1f4; padding: 1px 6px; border-radius: 4px; }


### PR DESCRIPTION
## Summary
- Adds a standalone Express proxy under `white-label-proxy-server/` that runs on `localhost:9090` and forwards SDK assets, `/v1|/v2` API calls, and WebSocket upgrades to configurable upstreams (`SDK_UPSTREAM`, `SDK_CARD_UPSTREAM`, `SDK_3DS_UPSTREAM`, `BACKEND_URL`, `BACKEND_WS_URL`).
- Lets partner test pages load the SDK from a non-Yuno origin so the white-label rename in [sdk-web PR #2086](https://github.com/yuno-payments/sdk-web/pull/2086) can be exercised end-to-end: `window.SdkPayments`, `sdk-payments-ready` event, and no `yuno-*` DOM tokens leaking to the merchant page.
- Independent subproject with its own `package.json` / lockfile; secrets stay in `.env` (gitignored), `.env.example` documents knobs.
- Bumps root `package.json` version to 1.9.0.

## Test plan
- [ ] `cd white-label-proxy-server && cp .env.example .env && npm install && npm start` — server boots on `:9090`
- [ ] Landing page at `http://localhost:9090/` loads and resolves `main.js` from `versions.json`
- [ ] SDK requests to `/v<x>/main.js`, `/v<x>/pages/*`, `/challenge.html`, `/redirect.html`, `/session-id.html` route to the correct upstream
- [ ] `/v1/*` and `/v2/*` calls forward to `BACKEND_URL` and CORS headers come from the proxy (not upstream)
- [ ] WebSocket upgrades to `/checkout-websocket-notification-ms/ws/{payment,enrollment}` succeed against `BACKEND_WS_URL`
- [ ] Pointing a partner page at `http://localhost:9090` exposes `window.SdkPayments` and fires `sdk-payments-ready` with no `yuno-*` DOM leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New dev-only test harness and documentation; no changes to production SDK or payment logic beyond a version bump in the root demo package.
> 
> **Overview**
> Adds a **standalone** `white-label-proxy-server/` subproject (own `package.json`, lockfile, docs) so partner pages can load the SDK from **`localhost:9090`** instead of `*.y.uno`, for end-to-end checks of the sdk-web white-label rename (`window.SdkPayments`, `sdk-payments-ready`, no `yuno-*` DOM leakage).
> 
> **`server.js`** implements an Express proxy on `:9090` that serves a small landing page and **`/whitelabel-info`**, forwards **`/v1/*` and `/v2/*`** to `BACKEND_URL` (JSON body re-serialized after `express.json()`), proxies GET/HEAD SDK traffic to **`SDK_UPSTREAM`**, **`SDK_CARD_UPSTREAM`**, or **`SDK_3DS_UPSTREAM`** by path, normalizes main-bundle version segments to `versions.json` **`latest`**, applies permissive CORS while stripping upstream `access-control-*`, and handles checkout WebSocket upgrades via **`http-proxy`**. Root **`package.json` version** is bumped **1.5.0 → 1.9.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99df1317026e9e647fd380d48dae55ef16e5fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->