### PR TITLE
feat:[CORECM-17664] migrate demos to whitelabel-neutral SdkPayments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -206,13 +206,13 @@ await yuno.startSeamlessCheckout({
   /**
    * Empty function.  Won't be called, but should be implemented
    */
-  async yunoCreatePayment() {},
+  async createPayment() {},
   /**
    * Callback is called when user selects a payment method
    * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY', name: string} } data 
    * @optional
    */
-  yunoPaymentMethodSelected(data) {
+  paymentMethodSelected(data) {
     console.log('onPaymentMethodSelected', data)
   },
   /**
@@ -220,8 +220,8 @@ await yuno.startSeamlessCheckout({
    * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
    * @optional
    */
-  yunoPaymentResult(data) {
-    console.log('yunoPaymentResult', data)
+  paymentResult(data) {
+    console.log('paymentResult', data)
     /**
      * call if you want to hide the loader 
      */
@@ -232,7 +232,7 @@ await yuno.startSeamlessCheckout({
    * @param { error: 'CANCELED_BY_USER' | string, data?: { cause: USER_CANCEL_ON_PROVIDER | string, provider: PAYPAL | string } }
    * @optional
    */
-  yunoError: (error, data) => {
+  error: (error, data) => {
     console.log('There was an error', error)
     /**
      * call if you want to hide the loader 
@@ -275,13 +275,13 @@ After it is mounted, it will start the desired flow
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -448,13 +448,13 @@ await yuno.startCheckout({
   /**
    * Empty function.  Won't be called, but should be implemented
    */
-  async yunoCreatePayment() {},
+  async createPayment() {},
   /**
    * Callback is called when user selects a payment method
    * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY', name: string} } data 
    * @optional
    */
-  yunoPaymentMethodSelected(data) {
+  paymentMethodSelected(data) {
     console.log('onPaymentMethodSelected', data)
   },
   /**
@@ -462,8 +462,8 @@ await yuno.startCheckout({
    * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
    * @optional
    */
-  yunoPaymentResult(data) {
-    console.log('yunoPaymentResult', data)
+  paymentResult(data) {
+    console.log('paymentResult', data)
     /**
      * call if you want to hide the loader 
      */
@@ -474,7 +474,7 @@ await yuno.startCheckout({
    * @param { error: 'CANCELED_BY_USER' | string, data?: { cause: USER_CANCEL_ON_PROVIDER | string, provider: PAYPAL | string } }
    * @optional
    */
-  yunoError: (error, data) => {
+  error: (error, data) => {
     console.log('There was an error', error)
     /**
      * call if you want to hide the loader 
@@ -511,13 +511,13 @@ After it is mounted, it will start the desired flow
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -559,13 +559,13 @@ Then create a configuration object
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'PAYED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     onLoading: (data) => {
@@ -581,7 +581,7 @@ Then create a configuration object
      * callback is called when user selects a payment method
      * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY' | 'MERCADO_PAGO_CHECKOUT_PRO', name: string} } data
      */
-    yunoPaymentMethodSelected(data) {
+    paymentMethodSelected(data) {
       console.log('onPaymentMethodSelected', data)
     },
   })
@@ -621,13 +621,13 @@ After it is mounted, it will start the desired flow
 To use full checkout you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then start checkout with configuration
@@ -796,7 +796,7 @@ await yuno.startCheckout({
    * Merchant should create payment back to back
    * @param { oneTimeToken: string, tokenWithInformation: object } data 
    */
-  async yunoCreatePayment(oneTimeToken, tokenWithInformation) {
+  async createPayment(oneTimeToken, tokenWithInformation) {
     /**
      * Merchant's function to call its backend to create 
      * the payment into Yuno.
@@ -822,7 +822,7 @@ await yuno.startCheckout({
    * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY', name: string} } data 
    * @optional
    */
-  yunoPaymentMethodSelected(data) {
+  paymentMethodSelected(data) {
     console.log('onPaymentMethodSelected', data)
   },
   /**
@@ -830,8 +830,8 @@ await yuno.startCheckout({
    * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
    * @optional
    */
-  yunoPaymentResult(data) {
-    console.log('yunoPaymentResult', data)
+  paymentResult(data) {
+    console.log('paymentResult', data)
 
     /**
      * call if you want to hide the loader 
@@ -843,7 +843,7 @@ await yuno.startCheckout({
    * @param { error: 'CANCELED_BY_USER' | string, data?: { cause: USER_CANCEL_ON_PROVIDER | string, provider: PAYPAL | string } }
    * @optional
    */
-  yunoError: (error, data) => {
+  error: (error, data) => {
     console.log('There was an error', error)
     /**
      * call if you want to hide the loader 
@@ -908,13 +908,13 @@ PayButton.addEventListener('click', () => {
 To use checkout lite you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -1083,7 +1083,7 @@ await yuno.startCheckout({
    * Merchant should create payment back to back
    * @param { oneTimeToken: string, tokenWithInformation: object } data 
    */
-  async yunoCreatePayment(oneTimeToken, tokenWithInformation) {
+  async createPayment(oneTimeToken, tokenWithInformation) {
     /**
      * Merchant's function to call its backend to create 
      * the payment into Yuno.
@@ -1101,7 +1101,7 @@ await yuno.startCheckout({
    * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY', name: string} } data 
    * @optional
    */
-  yunoPaymentMethodSelected(data) {
+  paymentMethodSelected(data) {
     console.log('onPaymentMethodSelected', data)
   },
   /**
@@ -1109,8 +1109,8 @@ await yuno.startCheckout({
    * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
    * @optional
    */
-  yunoPaymentResult(data) {
-    console.log('yunoPaymentResult', data)
+  paymentResult(data) {
+    console.log('paymentResult', data)
     /**
      * call if you want to hide the loader 
      */
@@ -1121,7 +1121,7 @@ await yuno.startCheckout({
    * @param { error: 'CANCELED_BY_USER' | string, data?: { cause: USER_CANCEL_ON_PROVIDER | string, provider: PAYPAL | string } }
    * @optional
    */
-  yunoError: (error, data) => {
+  error: (error, data) => {
     console.log('There was an error', error)
     /**
      * call if you want to hide the loader 
@@ -1192,13 +1192,13 @@ await yuno.clearApiCache()
 To use checkout secure fields you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -1621,8 +1621,8 @@ if (payment.checkout.sdk_action_required) {
     /**
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
   })
 }
@@ -1636,13 +1636,13 @@ if (payment.checkout.sdk_action_required) {
 To use status you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Finally mount the **SDK** in a `html` element, you can use any valid css selector (`#`, `.`, `[data-*]`).
@@ -1664,8 +1664,8 @@ await yuno.mountStatusPayment({
   /**
    * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
    */
-  yunoPaymentResult(data) {
-    console.log('yunoPaymentResult', data)
+  paymentResult(data) {
+    console.log('paymentResult', data)
   }
 })
 ```
@@ -1678,16 +1678,16 @@ await yuno.mountStatusPayment({
 To use status lite you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
-Finally call the **SDK** `yunoPaymentResult` method.
+Finally call the **SDK** `paymentResult` method.
 
 ```javascript
 /**
@@ -1695,7 +1695,7 @@ Finally call the **SDK** `yunoPaymentResult` method.
  * 
  * @return {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'}
  */
-const status = await yuno.yunoPaymentResult(checkoutSession)
+const status = await yuno.paymentResult(checkoutSession)
 ```
 [Status Lite demo html](https://github.com/yuno-payments/yuno-sdk-web/blob/main/vanilla/pages/status-lite.html)  
 [Status Lite demo js](https://github.com/yuno-payments/yuno-sdk-web/blob/main/vanilla/static/status-lite.js)
@@ -1705,13 +1705,13 @@ const status = await yuno.yunoPaymentResult(checkoutSession)
 To use enrollment lite you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Finally call the **SDK** `mountEnrollmentLite` method.
@@ -1855,7 +1855,7 @@ await yuno.mountEnrollmentLite({
    *  vaultedToken: string,
    * }}
    */
-  yunoEnrollmentStatus: ({ status, vaultedToken}) => {
+  enrollmentStatus: ({ status, vaultedToken}) => {
     console.log('status', { status, vaultedToken})
   },
   /**
@@ -1863,7 +1863,7 @@ await yuno.mountEnrollmentLite({
    * @param { error: 'CANCELED_BY_USER' | string, data?: { cause: USER_CANCEL_ON_PROVIDER | string, provider: PAYPAL | string } }
    * @optional
    */
-  yunoError: (error, data) => {
+  error: (error, data) => {
     console.log('There was an error', error)
     /**
      * call if you want to hide the loader 
@@ -1881,13 +1881,13 @@ await yuno.mountEnrollmentLite({
 To use enrollment with secure fields you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
 
 ```javascript
-const yuno = await Yuno.initialize(PUBLIC_API_KEY)
+const yuno = await SdkPayments.initialize(PUBLIC_API_KEY)
 ```
 
 Then create a configuration object
@@ -2225,9 +2225,9 @@ Include Type in tsconfig.js or tsconfig.json
 how to use types in your code
 
 ```javascript
-import { YunoInstance } from '@yuno-payments/sdk-web-types'
+import { SdkPaymentsInstance } from '@yuno-payments/sdk-web-types'
 
-const yunoInstance: YunoInstance = await Yuno.initialize('publicApiKey')
+const yunoInstance: SdkPaymentsInstance = await SdkPayments.initialize('publicApiKey')
 ```
 
 ## Example

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -386,7 +386,7 @@ type RenderMode = {
 }
 type LoadingType = 'DOCUMENT' | 'ONE_TIME_TOKEN';
 type Language = 'es' | 'en' | 'pt';
-type YunoConfig = {
+type SdkPaymentsConfig = {
   /**
    * Check the {@link https://docs.y.uno/reference/get-your-api-credentials | Get your API credentials} guide.
    * @type {String}
@@ -474,13 +474,13 @@ type YunoConfig = {
    * @param { OneTimeToken } tokenWithInformation 
    * @returns void
    */
-  yunoCreatePayment?: (oneTimeToken: string, tokenWithInformation: OneTimeToken) => void;
+  createPayment?: (oneTimeToken: string, tokenWithInformation: OneTimeToken) => void;
   /**
    * Callback is called when user selects a payment method.
    * @param {{ type: string, name: string }} args 
    * @optional
    */
-  yunoPaymentMethodSelected?: (args: {
+  paymentMethodSelected?: (args: {
       type: string;
       name: string;
   }) => void;
@@ -489,14 +489,14 @@ type YunoConfig = {
    * @param {Status} status
    * @optional
    */
-  yunoPaymentResult?: (status: Status) => void;
+  paymentResult?: (status: Status) => void;
   /**
    * If this is called the SDK should be mounted again
    * @param {String} message
    * @param {String?} data
    * @optional
    */
-  yunoError?: (message: string, data?: string) => void;
+  error?: (message: string, data?: string) => void;
   /**
    * @optional
    */
@@ -510,7 +510,7 @@ type YunoConfig = {
    * callback called after the enrollment process has ended.
    * @param {{ status: EnrollmentStatus, vaultedToken?: string }} args
    */
-  yunoEnrollmentStatus?(args: {
+  enrollmentStatus?(args: {
     status: EnrollmentStatus;
     vaultedToken?: string;
   }): void;
@@ -542,16 +542,16 @@ type YunoConfig = {
   automaticallyUnmount?: boolean;
 }
 
-type StartCheckoutArgs = Pick<YunoConfig,
+type StartCheckoutArgs = Pick<SdkPaymentsConfig,
     | 'elementSelector'
     | 'checkoutSession'
     | 'language'
     | 'countryCode'
     | 'renderMode'
-    | 'yunoCreatePayment'
-    | 'yunoPaymentMethodSelected'
-    | 'yunoPaymentResult'
-    | 'yunoError'
+    | 'createPayment'
+    | 'paymentMethodSelected'
+    | 'paymentResult'
+    | 'error'
     | 'card'
     | 'showLoading'
     | 'onLoading'
@@ -600,11 +600,11 @@ type MountCheckoutLiteArgs = {
   vaultedToken?: string;
 }
 
-type MountEnrollmentLiteArgs = Pick<YunoConfig, 'language' | 'countryCode' | 'renderMode' | 'yunoEnrollmentStatus' | 'yunoError' | 'showLoading' | 'onRendered' | 'onOneTimeTokenCreationStart' | 'onLoading'>;
+type MountEnrollmentLiteArgs = Pick<SdkPaymentsConfig, 'language' | 'countryCode' | 'renderMode' | 'enrollmentStatus' | 'error' | 'showLoading' | 'onRendered' | 'onOneTimeTokenCreationStart' | 'onLoading'>;
 
-type mountFraudArgs = Pick<YunoConfig, 'yunoCreatePayment' | 'yunoError' | 'language' | 'checkoutSession'>;
+type mountFraudArgs = Pick<SdkPaymentsConfig, 'createPayment' | 'error' | 'language' | 'checkoutSession'>;
 
-type MountStatusPaymentArgs = Pick<YunoConfig, 'checkoutSession' | 'language' | 'countryCode' | 'yunoPaymentResult' | 'yunoError'>
+type MountStatusPaymentArgs = Pick<SdkPaymentsConfig, 'checkoutSession' | 'language' | 'countryCode' | 'paymentResult' | 'error'>
 
 type SecureFieldsArgs = {
   /**
@@ -645,7 +645,7 @@ type SecureFieldsArgs = {
   enableV2?: boolean;
 }
 
-type YunoInstance = {
+type SdkPaymentsInstance = {
   /**
    * Will start the checkout process.
    * @param {StartCheckoutArgs} args
@@ -701,7 +701,7 @@ type YunoInstance = {
    * Wil return payment status. This function wont render anything.
    * @type {Status}
    */
-  yunoPaymentResult(): Status;
+  paymentResult(): Status;
   /**
    * Will create `secure fields` instance
    * @param {SecureFieldsArgs} args 
@@ -709,19 +709,19 @@ type YunoInstance = {
   secureFields({ countryCode, checkoutSession, installmentEnable, customerSession }: SecureFieldsArgs): SecureFields;
 }
 
-interface Yuno {
+interface SdkPayments {
   /**
-   * Create an instance of the `Yuno` class by providing a valid **PUBLIC_API_KEY**.
+   * Create an instance of the `SdkPayments` class by providing a valid **PUBLIC_API_KEY**.
    * @param publicApiKey Check the {@link https://docs.y.uno/reference/get-your-api-credentials | Get your API credentials} guide.
    */
-  initialize(publicApiKey: string): YunoInstance;
+  initialize(publicApiKey: string): SdkPaymentsInstance;
 }
 
-export { type ButtonTextCard, type CardConfig, type Language, type LoadingType, type MountCheckoutArgs, type MountCheckoutLiteArgs, type MountEnrollmentLiteArgs, type RenderMode, type SecureFieldsArgs, type StartCheckoutArgs, type TextsCustom, type Yuno, type YunoConfig, type mountFraudArgs };
+export { type ButtonTextCard, type CardConfig, type Language, type LoadingType, type MountCheckoutArgs, type MountCheckoutLiteArgs, type MountEnrollmentLiteArgs, type RenderMode, type SecureFieldsArgs, type StartCheckoutArgs, type TextsCustom, type SdkPayments, type SdkPaymentsConfig, type mountFraudArgs };
 
 declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    Yuno: Yuno
+    SdkPayments: SdkPayments
   }
 }

--- a/vanilla/pages/checkout-lite.html
+++ b/vanilla/pages/checkout-lite.html
@@ -17,6 +17,6 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="../static/checkout-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout-seamless-external-buttons.html
+++ b/vanilla/pages/checkout-seamless-external-buttons.html
@@ -16,8 +16,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <script>
-    window.addEventListener('yuno-sdk-ready', () => {
-      console.log('Yuno SDK is ready', window.Yuno)
+    window.addEventListener('sdk-payments-ready', () => {
+      console.log('Yuno SDK is ready', window.SdkPayments)
     })
   </script>
   <script type="module" src="/static/checkout-seamless-external-buttons.js"></script>
@@ -45,7 +45,7 @@
   <button id="mount-paypal-enrollment">Mount PayPal Enrollment</button>
   <button id="mount-apple-pay">Mount Apple Pay</button>
   <button id="mount-google-pay">Mount Google Pay</button>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 
 </html>

--- a/vanilla/pages/checkout-seamless-lite.html
+++ b/vanilla/pages/checkout-seamless-lite.html
@@ -17,6 +17,6 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="/static/checkout-seamless-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout-seamless.html
+++ b/vanilla/pages/checkout-seamless.html
@@ -19,6 +19,6 @@
   <button id="button-pay">Pagar Ahora</button>
 
   <script type="module" src="/static/checkout-seamless.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout-secure-fields.html
+++ b/vanilla/pages/checkout-secure-fields.html
@@ -27,6 +27,6 @@
   <button id="button-pay" disabled style="display: none;">Pay Now</button>
 
   <script type="module" src="/static/checkout-secure-fields.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout.html
+++ b/vanilla/pages/checkout.html
@@ -24,6 +24,6 @@
   <script type="module" src="../static/checkout.js"></script>
   
   <!-- include Yuno SDK -->
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/enrollment-lite.html
+++ b/vanilla/pages/enrollment-lite.html
@@ -17,6 +17,6 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="../static/enrollment-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/index.html
+++ b/vanilla/pages/index.html
@@ -24,6 +24,6 @@
 
   <script src="../static/loader.js"></script>
   <script type="module" src="../static/checkout.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/payment-methods-unfolded.html
+++ b/vanilla/pages/payment-methods-unfolded.html
@@ -97,7 +97,7 @@
   <div id="root"></div>
 
   <script type="module" src="../static/payment-methods-unfolded.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 
 </html>

--- a/vanilla/pages/status-lite.html
+++ b/vanilla/pages/status-lite.html
@@ -16,6 +16,6 @@
   <div id="root"></div>
 
   <script type="module" src="../static/status-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/status.html
+++ b/vanilla/pages/status.html
@@ -16,6 +16,6 @@
   <div id="root"></div>
 
   <script type="module" src="../static/status.js"></script>
-  <script src="https://sdk-web.y.uno/v1.5/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/static/checkout-lite.js
+++ b/vanilla/static/checkout-lite.js
@@ -15,7 +15,7 @@ async function initCheckoutLite() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -36,7 +36,7 @@ async function initCheckoutLite() {
      * merchant should create payment back to back
      * @param { oneTimeToken: string } data 
      */
-    async yunoCreatePayment(oneTimeToken) {
+    async createPayment(oneTimeToken) {
       await createPayment({ oneTimeToken, checkoutSession })
 
       /**
@@ -48,13 +48,13 @@ async function initCheckoutLite() {
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     /**
@@ -79,4 +79,4 @@ async function initCheckoutLite() {
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initCheckoutLite)
+window.addEventListener('sdk-payments-ready', initCheckoutLite)

--- a/vanilla/static/checkout-seamless-external-buttons.js
+++ b/vanilla/static/checkout-seamless-external-buttons.js
@@ -10,7 +10,7 @@ async function initCheckoutSeamlessLite() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  yuno = await window.Yuno.initialize(publicApiKey)
+  yuno = await window.SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -47,13 +47,13 @@ async function initCheckoutSeamlessLite() {
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'PAYED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     onLoading: (data) => {
@@ -69,7 +69,7 @@ async function initCheckoutSeamlessLite() {
      * callback is called when user selects a payment method
      * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY' | 'MERCADO_PAGO_CHECKOUT_PRO', name: string} } data
      */
-    yunoPaymentMethodSelected(data) {
+    paymentMethodSelected(data) {
       console.log('onPaymentMethodSelected', data)
     },
   })
@@ -191,4 +191,4 @@ document.getElementById('mount-google-pay').addEventListener('click', mountGoogl
 document.getElementById('unmount-paypal-enrollment').addEventListener('click', unmountPaypalEnrollment)
 document.getElementById('mount-paypal-enrollment').addEventListener('click', mountPaypalEnrollment)
 
-window.addEventListener('yuno-sdk-ready', initCheckoutSeamlessLite)
+window.addEventListener('sdk-payments-ready', initCheckoutSeamlessLite)

--- a/vanilla/static/checkout-seamless-lite.js
+++ b/vanilla/static/checkout-seamless-lite.js
@@ -15,7 +15,7 @@ async function initSeamlessCheckoutLite() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -34,18 +34,18 @@ async function initSeamlessCheckoutLite() {
     /**
      * Empty function.  Won't be called, 
      */
-    async yunoCreatePayment() { },
+    async createPayment() { },
     /**
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     /**
@@ -70,4 +70,4 @@ async function initSeamlessCheckoutLite() {
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initSeamlessCheckoutLite)
+window.addEventListener('sdk-payments-ready', initSeamlessCheckoutLite)

--- a/vanilla/static/checkout-seamless.js
+++ b/vanilla/static/checkout-seamless.js
@@ -15,7 +15,7 @@ async function initSeamlessCheckoutLite() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -34,18 +34,18 @@ async function initSeamlessCheckoutLite() {
     /**
      * Empty function.  Won't be called, 
      */
-    async yunoCreatePayment() { },
+    async createPayment() { },
     /**
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     },
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     /**
@@ -67,4 +67,4 @@ async function initSeamlessCheckoutLite() {
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initSeamlessCheckoutLite)
+window.addEventListener('sdk-payments-ready', initSeamlessCheckoutLite)

--- a/vanilla/static/checkout-secure-fields.js
+++ b/vanilla/static/checkout-secure-fields.js
@@ -37,7 +37,7 @@ async function initCheckoutSecureFields() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -263,11 +263,11 @@ async function initCheckoutSecureFields() {
       /**
        * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
        */
-      yunoPaymentResult(data) {
-        console.log('yunoPaymentResult', data)
+      paymentResult(data) {
+        console.log('paymentResult', data)
       },
     })
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initCheckoutSecureFields)
+window.addEventListener('sdk-payments-ready', initCheckoutSecureFields)

--- a/vanilla/static/checkout.js
+++ b/vanilla/static/checkout.js
@@ -8,7 +8,7 @@ async function initCheckout() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * checkout configuration
    */
@@ -110,7 +110,7 @@ async function initCheckout() {
      * merchant should create payment back to back
      * @param { oneTimeToken: string } data 
      */
-    async yunoCreatePayment(oneTimeToken) {
+    async createPayment(oneTimeToken) {
       loader.style.display = 'block'
       isPaying = true
 
@@ -125,15 +125,15 @@ async function initCheckout() {
      * callback is called when user selects a payment method
      * @param { {type: 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY' | 'MERCADO_PAGO_CHECKOUT_PRO', name: string} } data 
      */
-    yunoPaymentMethodSelected(data) {
+    paymentMethodSelected(data) {
       console.log('onPaymentMethodSelected', data)
     },
     /**
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
       /**
        * call if you set `keepLoader = true` and you want to hide the loader 
        */
@@ -142,7 +142,7 @@ async function initCheckout() {
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
       /**
        * call if you set `keepLoader = true` and you want to hide the loader 
@@ -165,4 +165,4 @@ async function initCheckout() {
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initCheckout)
+window.addEventListener('sdk-payments-ready', initCheckout)

--- a/vanilla/static/enrollment-lite.js
+++ b/vanilla/static/enrollment-lite.js
@@ -11,7 +11,7 @@ async function initEnrollmentLite() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
 
   yuno.mountEnrollmentLite({
     customerSession,
@@ -66,7 +66,7 @@ async function initEnrollmentLite() {
     /**
      * @param { error: 'CANCELED_BY_USER' | any }
      */
-    yunoError: (error) => {
+    error: (error) => {
       console.log('There was an error', error)
     },
     /**
@@ -86,10 +86,10 @@ async function initEnrollmentLite() {
      *  vaultedToken: string,
      * }}
      */
-    yunoEnrollmentStatus: ({ status, vaultedToken }) => {
+    enrollmentStatus: ({ status, vaultedToken }) => {
       console.log('status', { status, vaultedToken })
     },
   });
 }
 
-window.addEventListener('yuno-sdk-ready', initEnrollmentLite)
+window.addEventListener('sdk-payments-ready', initEnrollmentLite)

--- a/vanilla/static/payment-methods-unfolded.js
+++ b/vanilla/static/payment-methods-unfolded.js
@@ -6,7 +6,7 @@ async function initCheckout() {
   const publicApiKey = await getPublicApiKey()
   const paymentMethodsList = await getPaymentMethods(checkoutSession)
 
-  const yunoInstance = await Yuno.initialize(publicApiKey)
+  const yunoInstance = await SdkPayments.initialize(publicApiKey)
 
   const loadChekoutLite = async (paymentMethod, optionId) => {
     resetStateList(paymentMethodsList)
@@ -19,7 +19,7 @@ async function initCheckout() {
       language: 'en',
       showLoading: false,
       showPayButton: false,
-      yunoCreatePayment: async (oneTimeToken) => {
+      createPayment: async (oneTimeToken) => {
         try {
           const response = await createPayment({ oneTimeToken, checkoutSession })
           //verify if the payment method requires an action
@@ -31,7 +31,7 @@ async function initCheckout() {
               checkoutSession,
               language: 'en',
               countryCode,
-              yunoPaymentResult: async (data) => {
+              paymentResult: async (data) => {
                 //When closing the screen, if the user wants to retry, a new checkout session must be created because the previous one has already been used
                 resetStateList(paymentMethodsList)
               }
@@ -85,4 +85,4 @@ async function initCheckout() {
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initCheckout)
+window.addEventListener('sdk-payments-ready', initCheckout)

--- a/vanilla/static/status-lite.js
+++ b/vanilla/static/status-lite.js
@@ -5,7 +5,7 @@ async function initStatus() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
 
   const checkoutSession = '438413b7-4921-41e4-b8f3-28a5a0141638'
 
@@ -14,9 +14,9 @@ async function initStatus() {
    * 
    * @return {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'}
    */
-  const status = await yuno.yunoPaymentResult(checkoutSession)
+  const status = await yuno.paymentResult(checkoutSession)
 
   document.write(`Payment Status: ${status}`)
 }
 
-window.addEventListener('yuno-sdk-ready', initStatus)
+window.addEventListener('sdk-payments-ready', initStatus)

--- a/vanilla/static/status.js
+++ b/vanilla/static/status.js
@@ -5,7 +5,7 @@ async function initStatus() {
   const publicApiKey = await getPublicApiKey()
 
   // start Yuno SDK
-  const yuno = await Yuno.initialize(publicApiKey)
+  const yuno = await SdkPayments.initialize(publicApiKey)
   /**
    * Mount status in the DOM
    */
@@ -23,10 +23,10 @@ async function initStatus() {
      * 
      * @param {'READY_TO_PAY' | 'CREATED' | 'SUCCEEDED' | 'REJECTED' | 'CANCELLED' | 'ERROR' | 'DECLINED' | 'PENDING' | 'EXPIRED' | 'VERIFIED' | 'REFUNDED'} data
      */
-    yunoPaymentResult(data) {
-      console.log('yunoPaymentResult', data)
+    paymentResult(data) {
+      console.log('paymentResult', data)
     }
   })
 }
 
-window.addEventListener('yuno-sdk-ready', initStatus)
+window.addEventListener('sdk-payments-ready', initStatus)

--- a/yuno-angular/package-lock.json
+++ b/yuno-angular/package-lock.json
@@ -16,8 +16,8 @@
         "@angular/platform-browser": "^19.2.19",
         "@angular/platform-browser-dynamic": "^19.2.19",
         "@angular/router": "^19.2.19",
-        "@yuno-payments/sdk-web": "^3.0.0",
-        "@yuno-payments/sdk-web-types": "^4.4.0",
+        "@yuno-payments/sdk-web": "^7.1.0",
+        "@yuno-payments/sdk-web-types": "^5.5.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -6023,18 +6023,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@yuno-payments/sdk-web": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-3.1.0.tgz",
-      "integrity": "sha512-5JtxoIs1J6uijZPWkb+KrbbZEUXaIka96/CSZJGt4ugbtRP/o3wc0GjVzoVBVhTtagfsd5uxseXkKlnM+W16kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-7.1.0.tgz",
+      "integrity": "sha512-+ykULLhUaGQ/ko/8mHGHBw+AaabPLTsrh7XI5C44f/KV8LN8VrHZnmQ2gjIUu4tWNshXfTa2eEYiLcCzT1LuCQ==",
       "license": "ISC",
       "dependencies": {
-        "@yuno-payments/sdk-web-types": "^4.6.0"
+        "@yuno-payments/sdk-web-types": "^5.5.0"
       }
     },
     "node_modules/@yuno-payments/sdk-web-types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-4.6.0.tgz",
-      "integrity": "sha512-SUy4TCIm+0HpX0vOlkI0QB0bddqmOfijZ4j5mC5jNJeevpiuAidZxqjUZUR6oad2bjOYQACvYs8+OnbrPpaphQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-5.5.0.tgz",
+      "integrity": "sha512-zVszyYyJvBwObc4xxDraYsaGJXQyFE13R7hPStMa/ASsisjxdM6cXHLl0Sg85V2idU34qASb7xNUaLrDx0W0Gg==",
       "license": "ISC"
     },
     "node_modules/abbrev": {

--- a/yuno-angular/package.json
+++ b/yuno-angular/package.json
@@ -18,8 +18,8 @@
     "@angular/platform-browser": "^19.2.19",
     "@angular/platform-browser-dynamic": "^19.2.19",
     "@angular/router": "^19.2.19",
-    "@yuno-payments/sdk-web": "^3.0.0",
-    "@yuno-payments/sdk-web-types": "^4.4.0",
+    "@yuno-payments/sdk-web": "^7.1.0",
+    "@yuno-payments/sdk-web-types": "^5.5.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/yuno-angular/src/app/components/sdk-full/sdk-full.component.ts
+++ b/yuno-angular/src/app/components/sdk-full/sdk-full.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { loadScript } from '@yuno-payments/sdk-web';
-import { YunoInstance } from '@yuno-payments/sdk-web-types';
+import { SdkPaymentsInstance } from '@yuno-payments/sdk-web-types';
 
 const PUBLIC_API_KEY = '';
 const CHECKOUT_SESSION = '';
@@ -12,7 +12,7 @@ const CHECKOUT_SESSION = '';
   styleUrl: './sdk-full.component.scss',
 })
 export class SdkFullComponent implements OnInit {
-  yunoInstance?: YunoInstance;
+  yunoInstance?: SdkPaymentsInstance;
   async ngOnInit() {
     const yuno = await loadScript();
     this.yunoInstance = await yuno.initialize(PUBLIC_API_KEY);
@@ -21,7 +21,7 @@ export class SdkFullComponent implements OnInit {
       countryCode: 'CO',
       language: 'es',
       elementSelector: '#sdk-root',
-      yunoCreatePayment: (oneTimeToken, tokenWithInformation) => {
+      createPayment: (oneTimeToken, tokenWithInformation) => {
         console.log('tokenWithInformation', tokenWithInformation);
         console.log('oneTimeToken', oneTimeToken);
         // you create payment with token

--- a/yuno-react/package-lock.json
+++ b/yuno-react/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@emotion/styled": "^11.14.0",
-        "@yuno-payments/sdk-web": "^3.0.0",
-        "@yuno-payments/sdk-web-types": "^4.4.0",
+        "@yuno-payments/sdk-web": "^7.1.0",
+        "@yuno-payments/sdk-web-types": "^5.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.12.0"
@@ -1895,18 +1895,18 @@
       }
     },
     "node_modules/@yuno-payments/sdk-web": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-3.1.0.tgz",
-      "integrity": "sha512-5JtxoIs1J6uijZPWkb+KrbbZEUXaIka96/CSZJGt4ugbtRP/o3wc0GjVzoVBVhTtagfsd5uxseXkKlnM+W16kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-7.1.0.tgz",
+      "integrity": "sha512-+ykULLhUaGQ/ko/8mHGHBw+AaabPLTsrh7XI5C44f/KV8LN8VrHZnmQ2gjIUu4tWNshXfTa2eEYiLcCzT1LuCQ==",
       "license": "ISC",
       "dependencies": {
-        "@yuno-payments/sdk-web-types": "^4.6.0"
+        "@yuno-payments/sdk-web-types": "^5.5.0"
       }
     },
     "node_modules/@yuno-payments/sdk-web-types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-4.6.0.tgz",
-      "integrity": "sha512-SUy4TCIm+0HpX0vOlkI0QB0bddqmOfijZ4j5mC5jNJeevpiuAidZxqjUZUR6oad2bjOYQACvYs8+OnbrPpaphQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-5.5.0.tgz",
+      "integrity": "sha512-zVszyYyJvBwObc4xxDraYsaGJXQyFE13R7hPStMa/ASsisjxdM6cXHLl0Sg85V2idU34qASb7xNUaLrDx0W0Gg==",
       "license": "ISC"
     },
     "node_modules/acorn": {

--- a/yuno-react/package.json
+++ b/yuno-react/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@emotion/styled": "^11.14.0",
-    "@yuno-payments/sdk-web": "^3.0.0",
-    "@yuno-payments/sdk-web-types": "^4.4.0",
+    "@yuno-payments/sdk-web": "^7.1.0",
+    "@yuno-payments/sdk-web-types": "^5.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.12.0"

--- a/yuno-react/src/app.tsx
+++ b/yuno-react/src/app.tsx
@@ -3,14 +3,14 @@ import { router } from "./routes";
 import { AppContext } from "./context/app-context";
 import { useRef, useEffect, useState } from "react";
 import { loadScript } from "@yuno-payments/sdk-web";
-import type { YunoInstance } from "@yuno-payments/sdk-web-types";
+import type { SdkPaymentsInstance } from "@yuno-payments/sdk-web-types";
 
 const PUBLIC_API_KEY = "";
 const CHECKOUT_SESSION = "";
 
 export const App = () => {
   const instanceFlag = useRef(0);
-  const [yunoInstance, setYunoInstance] = useState<YunoInstance | null>(null);
+  const [yunoInstance, setYunoInstance] = useState<SdkPaymentsInstance | null>(null);
 
   useEffect(() => {
     const createYunoInstance = async () => {

--- a/yuno-react/src/components/apm-lite-custom-loader/apm-lite-custom-loader.tsx
+++ b/yuno-react/src/components/apm-lite-custom-loader/apm-lite-custom-loader.tsx
@@ -20,7 +20,7 @@ export const ApmLiteCustomLoader: React.FC<{
           countryCode,
           language: 'es',
           showLoading: false,
-          yunoCreatePayment: async (token) => {
+          createPayment: async (token) => {
             console.log('token ----->', token)
             try {
               await yunoInstance.continuePayment()
@@ -30,7 +30,7 @@ export const ApmLiteCustomLoader: React.FC<{
               setShowLoader(false)
             }
           },
-          yunoError: (err) => {
+          error: (err) => {
             if (err === 'CANCELED_BY_USER') {
               onClose()
             }

--- a/yuno-react/src/components/apm-lite/apm-lite.tsx
+++ b/yuno-react/src/components/apm-lite/apm-lite.tsx
@@ -17,7 +17,7 @@ export const ApmLite: React.FC<{
         elementSelector: "#root-apm-yuno",
         countryCode,
         language: 'es',
-        yunoCreatePayment: async (token) => {
+        createPayment: async (token) => {
           console.log('token ----->', token)
           try {
             await yunoInstance.continuePayment()
@@ -26,7 +26,7 @@ export const ApmLite: React.FC<{
             onClose()
           }
         },
-        yunoError: (err) => {
+        error: (err) => {
           if (err === 'CANCELED_BY_USER') {
             onClose()
           }

--- a/yuno-react/src/context/app-context.ts
+++ b/yuno-react/src/context/app-context.ts
@@ -1,10 +1,10 @@
 import { createContext } from 'react'
-import type { YunoInstance } from '@yuno-payments/sdk-web-types'
+import type { SdkPaymentsInstance } from '@yuno-payments/sdk-web-types'
 
 type AppContextType = {
   checkoutSession: string
   countryCode: string
-  yunoInstance: YunoInstance
+  yunoInstance: SdkPaymentsInstance
 }
 
-export const AppContext = createContext<AppContextType>({ checkoutSession: '', countryCode: '', yunoInstance: {} as YunoInstance })
+export const AppContext = createContext<AppContextType>({ checkoutSession: '', countryCode: '', yunoInstance: {} as SdkPaymentsInstance })

--- a/yuno-vue/package-lock.json
+++ b/yuno-vue/package-lock.json
@@ -8,8 +8,8 @@
       "name": "yuno-vue-2",
       "version": "0.0.0",
       "dependencies": {
-        "@yuno-payments/sdk-web": "^3.0.0",
-        "@yuno-payments/sdk-web-types": "^4.4.0",
+        "@yuno-payments/sdk-web": "^7.1.0",
+        "@yuno-payments/sdk-web-types": "^5.5.0",
         "vue": "^3.5.13",
         "vue-router": "^4.5.1"
       },
@@ -1088,18 +1088,18 @@
       }
     },
     "node_modules/@yuno-payments/sdk-web": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-3.1.0.tgz",
-      "integrity": "sha512-5JtxoIs1J6uijZPWkb+KrbbZEUXaIka96/CSZJGt4ugbtRP/o3wc0GjVzoVBVhTtagfsd5uxseXkKlnM+W16kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web/-/sdk-web-7.1.0.tgz",
+      "integrity": "sha512-+ykULLhUaGQ/ko/8mHGHBw+AaabPLTsrh7XI5C44f/KV8LN8VrHZnmQ2gjIUu4tWNshXfTa2eEYiLcCzT1LuCQ==",
       "license": "ISC",
       "dependencies": {
-        "@yuno-payments/sdk-web-types": "^4.6.0"
+        "@yuno-payments/sdk-web-types": "^5.5.0"
       }
     },
     "node_modules/@yuno-payments/sdk-web-types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-4.6.0.tgz",
-      "integrity": "sha512-SUy4TCIm+0HpX0vOlkI0QB0bddqmOfijZ4j5mC5jNJeevpiuAidZxqjUZUR6oad2bjOYQACvYs8+OnbrPpaphQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@yuno-payments/sdk-web-types/-/sdk-web-types-5.5.0.tgz",
+      "integrity": "sha512-zVszyYyJvBwObc4xxDraYsaGJXQyFE13R7hPStMa/ASsisjxdM6cXHLl0Sg85V2idU34qASb7xNUaLrDx0W0Gg==",
       "license": "ISC"
     },
     "node_modules/alien-signals": {

--- a/yuno-vue/package.json
+++ b/yuno-vue/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@yuno-payments/sdk-web": "^3.0.0",
-    "@yuno-payments/sdk-web-types": "^4.4.0",
+    "@yuno-payments/sdk-web": "^7.1.0",
+    "@yuno-payments/sdk-web-types": "^5.5.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"
   },

--- a/yuno-vue/src/views/checkout-lite/checkout-lite.ts
+++ b/yuno-vue/src/views/checkout-lite/checkout-lite.ts
@@ -14,7 +14,7 @@ export const startPayment = async () => {
     elementSelector: "#yuno-root",
     countryCode: "CO",
     language: "es",
-    async yunoCreatePayment(oneTimeToken, tokenWithInformation) {
+    async createPayment(oneTimeToken, tokenWithInformation) {
       alert(`Token: ${oneTimeToken}`);
       console.log("token", oneTimeToken, tokenWithInformation);
     },


### PR DESCRIPTION
## Summary

Migrates the SDK demo apps from the deprecated `window.Yuno` / `yuno-*` callback surface to the whitelabel-neutral **SdkPayments** API, mirroring the PYORK-26 migration already shipped in `sdk-web-package` (the `@yuno-payments/sdk-web` wrapper, now v7.x). The demos now standardize on the neutral names and require the SDK v1.9.0+ contract — no legacy fallbacks.

## Changes

**API surface (callbacks)**
- `yunoCreatePayment` → `createPayment`
- `yunoPaymentMethodSelected` → `paymentMethodSelected`
- `yunoPaymentResult` → `paymentResult` (config callback **and** instance method)
- `yunoError` → `error`
- `yunoEnrollmentStatus` → `enrollmentStatus`

**Global + event**
- `window.Yuno` → `window.SdkPayments` (and bare `Yuno.initialize` → `SdkPayments.initialize`)
- `yuno-sdk-ready` → `sdk-payments-ready`

**Vanilla demos** — bump CDN script `v1.5/main.js` → `v1.9/main.js` (the neutral API only exists in v1.9.0+).

**Framework demos (react/vue/angular)**
- `@yuno-payments/sdk-web` `^3.0.0` → `^7.1.0` (neutral `loadScript` returns the `SdkPayments` factory and loads v1.9)
- `@yuno-payments/sdk-web-types` `^4.4.0` → `^5.5.0` (neutral type names)
- type imports `YunoInstance` → `SdkPaymentsInstance`
- lockfiles regenerated (resolve sdk-web@7.1.0 + sdk-web-types@5.5.0, deduped)

**Types** (`typescript/types.ts`) — `YunoConfig`/`YunoInstance`/`Yuno` → `SdkPaymentsConfig`/`SdkPaymentsInstance`/`SdkPayments`, including the `Window` global.

**README** — migrated the current integration examples; **preserved** the historical "Changes in v1.1/v1.2" migration sections and SDK CSS class names.

## Verification
- ✅ All 10 vanilla JS files pass `node --check`
- ✅ `typescript/types.ts` passes `tsc --strict --noEmit` (0 errors)
- ✅ Every mapping verified against the live `v1.9/main.js` bundle (exposes both old + new; migration is runtime-safe)
- ✅ Lockfiles resolve sdk-web@7.1.0 + sdk-web-types@5.5.0, matching the reference exactly
- ⚠️ Full `npm install` + build of the three frameworks not run (heavy; pre-existing node-engine warnings). `loadScript` signature + type names confirmed against the published `sdk-web@7.1.0` / `sdk-web-types@5.5.0` definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking integration examples and type names for anyone copying demos; payment behavior depends on merchants adopting v1.9+ and the new callback keys with no legacy fallbacks in these samples.
> 
> **Overview**
> **Whitelabel-neutral SDK surface** replaces the old demo integration contract across vanilla HTML/JS, React, Vue, and Angular samples plus the main README and local `typescript/types.ts`.
> 
> Initialization moves from `Yuno.initialize` / `window.Yuno` to **`SdkPayments.initialize` / `window.SdkPayments`**, and readiness hooks use **`sdk-payments-ready`** instead of `yuno-sdk-ready`. Checkout config callbacks are renamed (`createPayment`, `paymentMethodSelected`, `paymentResult`, `error`, `enrollmentStatus`), including the status-lite **`paymentResult`** instance method formerly named `yunoPaymentResult`.
> 
> Vanilla pages bump the CDN script from **`v1.5/main.js` to `v1.9/main.js`**. Framework demos upgrade **`@yuno-payments/sdk-web` to ^7.1.0** and **`sdk-web-types` to ^5.5.0**, with types renamed to `SdkPayments`, `SdkPaymentsConfig`, and `SdkPaymentsInstance`. Historical “Changes in v1.1/v1.2” README sections are left on the legacy naming on purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c670559afc0e10c1d24f7029a20dc5f4b227997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->