### PR TITLE
feat:[CORECM-18149] white-label proxy: sdk-checkout app + BFF for Payment Link

### DIFF
--- a/white-label-proxy-server/.env.example
+++ b/white-label-proxy-server/.env.example
@@ -57,6 +57,35 @@ SDK_STATIC_UPSTREAM=https://sdk.prod.y.uno
 SDK_ICONS_UPSTREAM=https://icons.prod.y.uno
 
 # -----------------------------------------------------------------------------
+# CHECKOUT_UPSTREAM — the sdk-checkout React app shell (hosted at checkout.<env>
+# .y.uno). Serves the SPA routes /payment, /payment/status, /enroll plus the CRA
+# bundle (/static/*) and root public files (favicon.ico, manifest.json,
+# robots.txt). This is what a merchant white-labels when they map
+#   checkout.y.uno/payment?session=…  →  host/<BASE_PATH>/payment?session=…
+# The served index.html has its absolute PUBLIC_URL asset origin rewritten to
+# BASE_PATH so the bundle loads back through this proxy, not the Yuno host.
+#   production : https://checkout.y.uno
+#   staging    : https://checkout.staging.y.uno
+#   sandbox    : https://checkout.sandbox.y.uno
+#   dev        : https://checkout.dev.y.uno
+# -----------------------------------------------------------------------------
+CHECKOUT_UPSTREAM=https://checkout.sandbox.y.uno
+
+# -----------------------------------------------------------------------------
+# CHECKOUT_BFF_UPSTREAM — the checkout BFF the sdk-checkout app calls. Its axios
+# baseURL is the white-labeled apiUrl (host/<BASE_PATH>/checkout-bff/v1), so
+# after the BASE_PATH strip the proxy forwards /checkout-bff/* here. Endpoints:
+#   GET  /checkout-bff/v1/checkout-info/{session}
+#   POST /checkout-bff/v1/checkout/payment
+# Host is `<env>.y.uno` (NO `api-` prefix):
+#   production : https://prod.y.uno
+#   staging    : https://staging.y.uno
+#   sandbox    : https://sandbox.y.uno
+#   dev        : https://dev.y.uno
+# -----------------------------------------------------------------------------
+CHECKOUT_BFF_UPSTREAM=https://sandbox.y.uno
+
+# -----------------------------------------------------------------------------
 # BASE_PATH — optional sub-path this proxy is "mounted" under, mirroring a
 # partner gateway served from e.g.
 #   https://host/hosted-payment-methods/hosted-payment-form/orchestrator

--- a/white-label-proxy-server/CLAUDE.md
+++ b/white-label-proxy-server/CLAUDE.md
@@ -25,9 +25,20 @@ Single file: `server.js`. Routes are registered in this order (order matters):
    prefixed with `BASE_PATH`.
 1. JSON body parser + permissive CORS middleware (echoes caller origin, strips upstream CORS).
 2. Local routes: `/` (landing), `/static/*`, `/whitelabel-info`.
-3. **Backend pass-through**: `app.all('/v1/*' | '/v2/*', forwardToBackend)` → `BACKEND_URL`.
-   Uses `node-fetch`; re-serializes the body (since `express.json()` consumed it).
-4. **SDK upstream catch-all** (GET/HEAD): `proxyToUpstream` picks one upstream via `pickSdkUpstream`:
+3. **Backend pass-through**: `app.all('/v1/*' | '/v2/*', forwardToBackend)` → `BACKEND_URL`, and
+   `app.all('/checkout-bff/*', forwardToCheckoutBff)` → `CHECKOUT_BFF_UPSTREAM`. Both share `forwardHttp`
+   (node-fetch, re-serializes the body since `express.json()` consumed it, strips `cookie`).
+   The checkout BFF is what the sdk-checkout app hits via its white-labeled `apiUrl`
+   (`host/<BASE_PATH>/checkout-bff/v1/{checkout-info/{session},checkout/payment}`).
+4. **Checkout SPA routes** (GET, before the SDK catch-all): `app.get(CHECKOUT_ROUTE_RE, proxyCheckoutHtml)`
+   for `/payment`, `/payment/status`, `/enroll` → fetches `CHECKOUT_UPSTREAM/index.html` and rewrites the
+   absolute `PUBLIC_URL` origin (`checkout.<env>.y.uno`) to `BASE_PATH` so the bundle/favicon/manifest load
+   back through this proxy instead of leaking to the Yuno host. react-router resolves the actual route
+   client-side from `window.location`.
+5. **SDK/asset upstream catch-all** (GET/HEAD): `proxyToUpstream` picks one upstream via `pickSdkUpstream`:
+   - `CHECKOUT_UPSTREAM` for the checkout CRA bundle (`/static/(js|css|media)/*`) and root public files
+     (`/favicon.ico`, `/manifest.json`, `/robots.txt`, `/asset-manifest.json`) — checked first so they don't
+     fall through to the SDK icon upstream.
    - `SDK_3DS_UPSTREAM` for `/challenge.html`, `/redirect.html`, `/session-id.html`, and
      `/assets/(challenge|redirect|session-id|validate-url)*`.
    - `SDK_CARD_UPSTREAM` for `/v<semver>/pages/*` and `/v<semver>/assets/*`.
@@ -36,8 +47,8 @@ Single file: `server.js`. Routes are registered in this order (order matters):
    - `SDK_UPSTREAM` otherwise.
    For the main SDK upstream, the version segment is normalized to whatever `versions.json` says is `latest`,
    so partners can request any `/v<x>/main.js` and still hit the published build.
-5. 404 fallback.
-6. WebSocket upgrades on the underlying `http.Server` (Express middleware never sees `Upgrade`).
+6. 404 fallback.
+7. WebSocket upgrades on the underlying `http.Server` (Express middleware never sees `Upgrade`).
    Uses `http-proxy`. `/checkout-websocket-notification-ms/ws/{payment,enrollment}` → `BACKEND_WS_URL`;
    everything else follows the same SDK/card/3DS split as HTTP.
 

--- a/white-label-proxy-server/README.md
+++ b/white-label-proxy-server/README.md
@@ -1,20 +1,33 @@
 # white-label-proxy-server
 
-Test harness for [sdk-web PR #2086](https://github.com/yuno-payments/sdk-web/pull/2086) — the white-label rename
-(`window.SdkPayments`, `sdk-payments-ready` event, no `yuno-*` DOM tokens leaked to the merchant page).
+Local test harness for Yuno's white-label hosting. It emulates a merchant's own origin/sub-path in front of the
+Yuno checkout stack, so both white-label surfaces can be exercised end-to-end from a **non-Yuno origin**
+(`localhost:9090`):
 
-The server hosts a minimal landing page on a **non-Yuno origin** (`localhost:9090`) and transparently proxies all
-SDK asset, API, and WebSocket traffic upstream. Partner test pages — your own or another subproject — point their
-`<script src>` at this origin so the SDK loads from `localhost:9090` (no `*.y.uno` hostname), which is what
-exercises the white-label code paths end-to-end.
+1. **Payment Link white-label checkout ([CORECM-18149](https://yuno.atlassian.net/browse/CORECM-18149)).** The
+   `sdk-checkout` React app (normally `checkout.<env>.y.uno`) is served through this proxy so a merchant can map
+   `checkout.y.uno/payment?session=…` onto `their.host/<base-path>/payment?session=…`. The proxy serves the SPA
+   routes (`/payment`, `/payment/status`, `/enroll`), rewrites the CRA bundle origin back to itself, and forwards
+   the checkout BFF (`/checkout-bff/*`) and notification WebSocket upstream.
+2. **SDK white-label rename ([sdk-web PR #2086](https://github.com/yuno-payments/sdk-web/pull/2086)).**
+   `window.SdkPayments`, `sdk-payments-ready` event, no `yuno-*` DOM tokens leaked to the merchant page. Partner
+   test pages point their `<script src>` at this origin so the SDK loads from `localhost:9090` (no `*.y.uno`
+   hostname).
+
+The server hosts a minimal landing page and transparently proxies all checkout, SDK asset, API, and WebSocket
+traffic upstream, which is what exercises the white-label code paths end-to-end.
 
 ## What it does
 
 | Request                                                | Routed to                              |
 | ------------------------------------------------------ | -------------------------------------- |
 | `/`                                                    | Landing page (`pages/index.html`)      |
-| `/static/*`                                            | Local assets (`static/*`)              |
+| `/static/*` (proxy's own page assets)                  | Local assets (`static/*`)              |
 | `/whitelabel-info`                                     | JSON describing current upstream config |
+| `/payment`, `/payment/status`, `/enroll`               | `CHECKOUT_UPSTREAM` index.html (SPA)   |
+| `/static/(js\|css\|media)/*`, `/favicon.ico`, `/manifest.json`, `/robots.txt`, `/asset-manifest.json` | `CHECKOUT_UPSTREAM` (checkout CRA bundle) |
+| `/checkout-bff/*` (HTTP)                               | `CHECKOUT_BFF_UPSTREAM`                |
+| `/checkout-websocket-notification-ms/ws/{payment,enrollment}` (WS) | `BACKEND_WS_URL`          |
 | `/v1/*`, `/v2/*` (HTTP + WS)                           | `BACKEND_URL` / `BACKEND_WS_URL`       |
 | `/challenge.html`, `/redirect.html`, `/session-id.html`, `/assets/(challenge\|redirect\|session-id\|validate-url)*` | `SDK_3DS_UPSTREAM` |
 | `/v<semver>/pages/*`, `/v<semver>/assets/*`            | `SDK_CARD_UPSTREAM`                    |
@@ -22,10 +35,38 @@ exercises the white-label code paths end-to-end.
 | `/sdk-web/*`, `/flags/*`, bare brand images (`/Visa.png`, …) | `SDK_ICONS_UPSTREAM` (`icons.prod.y.uno`) |
 | Everything else (GET/HEAD)                             | `SDK_UPSTREAM`                         |
 
+> **Checkout CRA bundle vs. SDK bare images:** the checkout app's `/static/(js|css|media)/*` and root public
+> files (`/favicon.ico`, `/manifest.json`, …) are matched **before** the SDK icon rules so they route to
+> `CHECKOUT_UPSTREAM` and don't fall through to `icons.prod.y.uno`.
+
 > **Static assets (CORECM-17664):** the SDK used to load icons/logos/fonts directly from `icons.prod.y.uno` /
 > `sdk.prod.y.uno`, bypassing the white-label host. It now host-swaps them to this proxy (path preserved), so the
 > proxy forwards them by path prefix to the two asset CDNs. Requires an SDK build that includes the fix
 > (sdk-web + `@yuno/sdk-web-core` ≥ 7.5.0) and a partner page that inits with `{ apiUrl: '<this proxy origin>' }`.
+
+### Payment Link checkout white-label (CORECM-18149)
+
+A merchant white-labels the hosted checkout by mapping `checkout.<env>.y.uno/payment?session=…` onto their own
+`host/<BASE_PATH>/payment?session=…`. Emulate it locally with `CHECKOUT_UPSTREAM` (the `sdk-checkout` app shell)
+and `CHECKOUT_BFF_UPSTREAM` (the BFF it calls):
+
+- **SPA routes** (`/payment`, `/payment/status`, `/enroll`) fetch `CHECKOUT_UPSTREAM/index.html`; the proxy
+  rewrites the absolute `PUBLIC_URL` origin (`checkout.<env>.y.uno`) to `BASE_PATH` so the CRA bundle, favicon
+  and manifest load back through this proxy instead of leaking to the Yuno host. react-router resolves the actual
+  route client-side from `window.location`.
+- **BFF calls** — the checkout app's axios `baseURL` is the white-labeled `apiUrl`
+  (`host/<BASE_PATH>/checkout-bff/v1`). After the `BASE_PATH` strip the proxy sees `/checkout-bff/*` and forwards
+  it to `CHECKOUT_BFF_UPSTREAM` (`GET /checkout-bff/v1/checkout-info/{session}`,
+  `POST /checkout-bff/v1/checkout/payment`).
+- **Payment/enrollment status WebSocket** — `/checkout-websocket-notification-ms/ws/{payment,enrollment}` is
+  forwarded to `BACKEND_WS_URL`.
+
+The allowlist that gates `apiUrl`/`assetUrl` (`REACT_APP_WHITE_LABEL_ALLOWED_HOSTS`) lives in `sdk-checkout`;
+add `localhost` to the dev env there to test through this proxy. See `sdk-checkout/CLAUDE.md` and its `README.md`
+for the app-side wiring.
+
+To try it: point a browser at `http://localhost:9090<BASE_PATH>/payment?session=<checkout-session>` with a
+matching `CHECKOUT_UPSTREAM`/`CHECKOUT_BFF_UPSTREAM` env for the session's environment.
 
 ### Sub-path mounting (`BASE_PATH`)
 
@@ -75,10 +116,14 @@ calls succeed:
 cd .. && npm run start:dev
 ```
 
-Then open http://localhost:9090/ for the landing page (shows current proxy config). Point your own
-partner test pages at `http://localhost:9090` — e.g. load the SDK via
-`<script src="http://localhost:9090/v1.7/main.js">` — and the proxy will fetch it from `SDK_UPSTREAM`
-on your behalf so the SDK runs against a non-Yuno origin.
+Then open http://localhost:9090/ for the landing page (shows current proxy config). Two ways to exercise it:
+
+- **Payment Link checkout:** open `http://localhost:9090<BASE_PATH>/payment?session=<checkout-session>` with
+  `CHECKOUT_UPSTREAM`/`CHECKOUT_BFF_UPSTREAM` set to the session's environment. The checkout SPA renders under the
+  non-Yuno origin and calls the BFF back through the proxy.
+- **SDK:** point your own partner test pages at `http://localhost:9090` — e.g. load the SDK via
+  `<script src="http://localhost:9090/v1.7/main.js">` — and the proxy fetches it from `SDK_UPSTREAM` on your
+  behalf so the SDK runs against a non-Yuno origin.
 
 ## Environment variables
 
@@ -92,6 +137,8 @@ Copy `.env.example` to `.env` and adjust. Yuno hostnames follow two conventions:
 | -------------------- | --------------------------------------------- | -------------------------------- | ---------------------------------------- | ------------------------------------ |
 | `PORT`               | Proxy listen port                             | `9090`                           | `9090`                                   | `9090`                               |
 | `BASE_PATH`          | Sub-path the proxy is mounted under (stripped before routing); empty = root | _(empty)_ | _(empty)_ | `/hosted-payment-methods/.../orchestrator` |
+| `CHECKOUT_UPSTREAM`  | sdk-checkout app shell (`/payment`, `/enroll`, CRA bundle) | `https://checkout.y.uno` | `https://checkout.staging.y.uno`         | `https://checkout.dev.y.uno`         |
+| `CHECKOUT_BFF_UPSTREAM` | Checkout BFF (`/checkout-bff/*`); NO `api-` prefix      | `https://prod.y.uno`    | `https://staging.y.uno`                  | `https://dev.y.uno`                  |
 | `SDK_UPSTREAM`       | Main SDK bundle                               | `https://sdk-web.y.uno`          | `https://sdk-web.staging.y.uno`          | `https://sdk-web.dev.y.uno`          |
 | `SDK_CARD_UPSTREAM`  | Card-form / secure-fields micro-app           | `https://sdk-web-card.y.uno`     | `https://sdk-web-card.staging.y.uno`     | `https://sdk-web-card.dev.y.uno`     |
 | `SDK_3DS_UPSTREAM`   | 3DS challenge / redirect / session-id pages   | `https://sdk-3ds.y.uno`          | `https://sdk-3ds.staging.y.uno`          | `https://sdk-3ds.dev.y.uno`          |
@@ -104,6 +151,8 @@ Copy `.env.example` to `.env` and adjust. Yuno hostnames follow two conventions:
 Defaults:
 
 - `SDK_CARD_UPSTREAM`, `SDK_3DS_UPSTREAM`, `BACKEND_WS_URL` fall back to `SDK_UPSTREAM` / `BACKEND_URL` when unset.
+- `CHECKOUT_UPSTREAM` and `CHECKOUT_BFF_UPSTREAM` default to sandbox (`https://checkout.sandbox.y.uno`,
+  `https://sandbox.y.uno`) — set both to the environment matching your checkout session.
 - `SDK_MAIN_JS` is auto-resolved from `<SDK_UPSTREAM>/versions.json` (`latest.version`), falling back to `/v1.7/main.js`.
 - `BACKEND_URL` can also point at a local backend (`http://localhost:8080`) — run `cd .. && npm run start:dev`.
 

--- a/white-label-proxy-server/server.js
+++ b/white-label-proxy-server/server.js
@@ -25,6 +25,17 @@ const SDK_3DS_UPSTREAM = (process.env.SDK_3DS_UPSTREAM || SDK_UPSTREAM).replace(
 //   icons.prod.y.uno → /sdk-web, /flags, bare brand images (/Visa.png, …)
 const SDK_STATIC_UPSTREAM = (process.env.SDK_STATIC_UPSTREAM || 'https://sdk.prod.y.uno').replace(/\/$/, '')
 const SDK_ICONS_UPSTREAM = (process.env.SDK_ICONS_UPSTREAM || 'https://icons.prod.y.uno').replace(/\/$/, '')
+// sdk-checkout app shell (the React checkout hosted at checkout.<env>.y.uno).
+// Serves the SPA routes (/payment, /payment/status, /enroll) plus its CRA
+// bundle (/static/*) and root public files (favicon, manifest, robots). This
+// is what a merchant white-labels when they map checkout.y.uno/payment?session=
+// onto their own host/<base-path>/payment?session=.
+const CHECKOUT_UPSTREAM = (process.env.CHECKOUT_UPSTREAM || 'https://checkout.sandbox.y.uno').replace(/\/$/, '')
+// Checkout BFF that the sdk-checkout app calls. Its axios baseURL is the
+// white-labeled apiUrl, i.e. https://host/<base-path>/checkout-bff/v1, so after
+// the BASE_PATH strip the proxy sees /checkout-bff/* and forwards it here.
+// Always `<env>.y.uno` (no `api-` prefix): sandbox.y.uno, prod.y.uno, …
+const CHECKOUT_BFF_UPSTREAM = (process.env.CHECKOUT_BFF_UPSTREAM || 'https://sandbox.y.uno').replace(/\/$/, '')
 // Optional sub-path this proxy is "mounted" under, mirroring a partner gateway
 // served from e.g. https://host/hosted-payment-methods/hosted-payment-form/orchestrator.
 // Since CORECM-17664 the SDK preserves this prefix on every asset/API/WS request
@@ -58,8 +69,23 @@ const SDK_ICONS_RE = /^\/(?:sdk-web|flags)\//
 // Bare brand images at the root (e.g. /Visa.png, /boleto_logosimbolo.png) live
 // on icons.prod.y.uno. `?react` and other queries are tolerated.
 const ROOT_IMAGE_RE = /^\/[^/]+\.(?:png|svg|jpe?g|gif|webp)(?:\?.*)?$/i
+// sdk-checkout react-router routes (all serve the SPA index.html): /payment,
+// /payment/status, /enroll.
+const CHECKOUT_ROUTE_RE = /^\/(?:payment|enroll)(?:\/[^?]*)?$/
+// sdk-checkout CRA bundle. Root public files (favicon/manifest/robots) are
+// matched separately so they don't collide with the SDK's bare-image rule.
+const CHECKOUT_ASSET_RE = /^\/static\/(?:js|css|media)\//
+const CHECKOUT_ROOT_FILES = new Set(['/favicon.ico', '/manifest.json', '/robots.txt', '/asset-manifest.json'])
+
+// True for the checkout app's own assets (bundle + root public files) — routed
+// to CHECKOUT_UPSTREAM. Checked before the SDK split so /favicon.ico etc. don't
+// fall through to the SDK icon upstream.
+function isCheckoutAsset(reqPath) {
+  return CHECKOUT_ASSET_RE.test(reqPath) || CHECKOUT_ROOT_FILES.has(reqPath)
+}
 
 function pickSdkUpstream(reqPath) {
+  if (isCheckoutAsset(reqPath)) return CHECKOUT_UPSTREAM
   if (SDK_3DS_PATHS.has(reqPath) || SDK_3DS_ASSET_RE.test(reqPath)) return SDK_3DS_UPSTREAM
   if (CARD_ASSET_RE.test(reqPath)) return SDK_CARD_UPSTREAM
   if (SDK_STATIC_RE.test(reqPath)) return SDK_STATIC_UPSTREAM
@@ -152,6 +178,8 @@ app.get('/whitelabel-info', (_req, res) => {
     proxyPort: PORT,
     basePath: BASE_PATH || null,
     backend: BACKEND_URL,
+    checkoutUpstream: CHECKOUT_UPSTREAM,
+    checkoutBffUpstream: CHECKOUT_BFF_UPSTREAM,
     sdkUpstream: SDK_UPSTREAM,
     sdkCardUpstream: SDK_CARD_UPSTREAM,
     sdk3dsUpstream: SDK_3DS_UPSTREAM,
@@ -170,6 +198,15 @@ app.get('/whitelabel-info', (_req, res) => {
 
 app.all('/v1/*', forwardToBackend)
 app.all('/v2/*', forwardToBackend)
+
+// ---- checkout BFF pass-through (to CHECKOUT_BFF_UPSTREAM) -----------------
+//
+// The sdk-checkout app calls its BFF via the white-labeled apiUrl, which resolves
+// to https://host/<base-path>/checkout-bff/v1/*. After the BASE_PATH strip the
+// proxy sees /checkout-bff/* and forwards it to the real BFF host. Endpoints:
+//   GET  /checkout-bff/v1/checkout-info/{session}
+//   POST /checkout-bff/v1/checkout/payment
+app.all('/checkout-bff/*', forwardToCheckoutBff)
 
 // Headers that must not be copied across a hop (RFC 7230 §6.1) plus a few we
 // recompute or that node-fetch sets itself.
@@ -194,8 +231,16 @@ function pickRequestHeaders(req) {
   return out
 }
 
-async function forwardToBackend(req, res) {
-  const targetUrl = `${BACKEND_URL}${req.originalUrl}`
+function forwardToBackend(req, res) {
+  return forwardHttp(req, res, BACKEND_URL, 'backend')
+}
+
+function forwardToCheckoutBff(req, res) {
+  return forwardHttp(req, res, CHECKOUT_BFF_UPSTREAM, 'checkout-bff')
+}
+
+async function forwardHttp(req, res, base, label) {
+  const targetUrl = `${base}${req.originalUrl}`
   try {
     const headers = pickRequestHeaders(req)
     // Don't forward the partner page's browser cookies to the Yuno API. They
@@ -221,20 +266,59 @@ async function forwardToBackend(req, res) {
       if (lk.startsWith('access-control-')) continue
       res.set(k, v)
     }
-    res.set('x-white-label-proxy', 'backend')
+    res.set('x-white-label-proxy', label)
     const body = await upstream.text()
     res.send(body)
   } catch (err) {
-    console.error(`[backend-proxy] ${req.method} ${targetUrl} →`, err.message)
-    res.status(502).json({ error: 'backend_unreachable', target: targetUrl, detail: err.message })
+    console.error(`[${label}-proxy] ${req.method} ${targetUrl} →`, err.message)
+    res.status(502).json({ error: 'upstream_unreachable', target: targetUrl, detail: err.message })
   }
 }
+
+// ---- checkout app shell (SPA routes) -------------------------------------
+//
+// /payment, /payment/status and /enroll all resolve to the checkout SPA's
+// index.html (react-router does the rest client-side from window.location).
+// The served HTML's CRA bundle links are absolute (PUBLIC_URL=checkout.<env>
+// .y.uno), so we rewrite that origin to BASE_PATH to keep every follow-up
+// request (/static/*, favicon, …) on this proxy origin instead of leaking back
+// to the Yuno host. Registered before the SDK catch-all so it wins for /payment.
+
+async function proxyCheckoutHtml(req, res, next) {
+  const targetUrl = `${CHECKOUT_UPSTREAM}/index.html`
+  try {
+    const upstream = await fetch(targetUrl, {
+      method: 'GET',
+      redirect: 'follow',
+      headers: {
+        accept: req.headers.accept || 'text/html',
+        'user-agent': req.headers['user-agent'] || 'white-label-proxy',
+      },
+    })
+    if (!upstream.ok) return next()
+    let html = await upstream.text()
+    // Same-origin the bundle: https://checkout.<env>.y.uno/static/... → <BASE_PATH>/static/...
+    html = html.split(new URL(CHECKOUT_UPSTREAM).origin).join(BASE_PATH)
+    res.status(upstream.status)
+    res.set('content-type', 'text/html; charset=utf-8')
+    res.set('cache-control', 'no-store')
+    res.set('x-white-label-proxy', 'checkout')
+    res.send(html)
+  } catch (err) {
+    console.error(`[checkout-proxy] GET ${targetUrl} →`, err.message)
+    res.status(502).send(`Checkout upstream error: ${err.message}`)
+  }
+}
+
+app.get(CHECKOUT_ROUTE_RE, proxyCheckoutHtml)
 
 // ---- SDK assets (white-label host) ---------------------------------------
 //
 // The whole point of the proxy: the SDK is loaded from THIS origin, not from
 // sdk-web.y.uno. Every GET that didn't match a route above is transparently
 // forwarded to SDK_UPSTREAM. Registered last so it doesn't shadow / or /static.
+// Also serves the checkout CRA bundle + root files (pickSdkUpstream routes
+// /static/*, /favicon.ico, … to CHECKOUT_UPSTREAM).
 
 app.use((req, res, next) => {
   if (req.method !== 'GET' && req.method !== 'HEAD') return next()
@@ -242,6 +326,7 @@ app.use((req, res, next) => {
 })
 
 function labelForUpstream(upstreamBase) {
+  if (upstreamBase === CHECKOUT_UPSTREAM) return 'checkout'
   if (upstreamBase === SDK_3DS_UPSTREAM && SDK_3DS_UPSTREAM !== SDK_UPSTREAM) return '3ds'
   if (upstreamBase === SDK_CARD_UPSTREAM && SDK_CARD_UPSTREAM !== SDK_UPSTREAM) return 'card'
   if (upstreamBase === SDK_STATIC_UPSTREAM && SDK_STATIC_UPSTREAM !== SDK_UPSTREAM) return 'static'
@@ -334,6 +419,8 @@ detectSdkMainJs().finally(() => {
     console.log(` SDK static asset: ${SDK_STATIC_UPSTREAM}  (/icons, /css, /brands, /c2p)`)
     console.log(` SDK icons asset : ${SDK_ICONS_UPSTREAM}  (/sdk-web, /flags, /*.png)`)
     console.log(` SDK main.js     : ${sdkMainJsPath}`)
+    console.log(` Checkout app    : ${CHECKOUT_UPSTREAM}  (/payment, /enroll, /static)`)
+    console.log(` Checkout BFF    : ${CHECKOUT_BFF_UPSTREAM}  (/checkout-bff/*)`)
     console.log(` Backend (API)   : ${BACKEND_URL}`)
     console.log(` Backend (WS)    : ${BACKEND_WS_URL}${BACKEND_WS_URL === BACKEND_URL ? ' (same as backend)' : ''}`)
     console.log('----------------------------------------------------------------')


### PR DESCRIPTION
## What

Extends the `white-label-proxy-server` test harness so a merchant's own origin/sub-path can front Yuno's **hosted Payment Link checkout** end-to-end from a non-Yuno origin (`localhost:9090`), in addition to the existing SDK white-label rename harness.

## Changes

- **Checkout SPA routes** (`/payment`, `/payment/status`, `/enroll`) → fetch `CHECKOUT_UPSTREAM/index.html` and rewrite the absolute `PUBLIC_URL` bundle origin (`checkout.<env>.y.uno`) to `BASE_PATH`, so the CRA bundle/favicon/manifest load back through the proxy instead of leaking to the Yuno host. react-router resolves the route client-side.
- **Checkout CRA bundle + root public files** (`/static/(js|css|media)/*`, `/favicon.ico`, `/manifest.json`, `/robots.txt`, `/asset-manifest.json`) → routed to `CHECKOUT_UPSTREAM`, matched **before** the SDK icon rules so they don't fall through to `icons.prod.y.uno`.
- **Checkout BFF pass-through** (`/checkout-bff/*`) → forwarded to `CHECKOUT_BFF_UPSTREAM`. Refactored `forwardToBackend` into a shared `forwardHttp(base, label)` used by both backend and BFF.
- New env vars `CHECKOUT_UPSTREAM` / `CHECKOUT_BFF_UPSTREAM` (default sandbox), surfaced in `/whitelabel-info` and startup logs.
- Docs updated: `README.md`, `CLAUDE.md`, `.env.example`.

## Test plan

Point a browser at `http://localhost:9090<BASE_PATH>/payment?session=<checkout-session>` with `CHECKOUT_UPSTREAM`/`CHECKOUT_BFF_UPSTREAM` set to the session's environment. Requires `localhost` added to `REACT_APP_WHITE_LABEL_ALLOWED_HOSTS` in `sdk-checkout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)