### PR TITLE
fix:[CORECM-18657] - Bump react-router to 7.18.2 in yuno-react (GHSA-qwww-vcr4-c8h2)

### DIFF
--- a/yuno-react/package-lock.json
+++ b/yuno-react/package-lock.json
@@ -3192,9 +3192,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3214,12 +3214,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Bumps `react-router` / `react-router-dom` from 7.18.1 to 7.18.2 in the `yuno-react` demo app.

Refs CORECM-18657 / VULS-5385, Dependabot alert #300 (GHSA-qwww-vcr4-c8h2).

### Scope

Lockfile only. `package.json` already declares `react-router-dom: ^7.15.1`, which 7.18.2 satisfies, so no manifest change is needed. Edited surgically rather than regenerating the lockfile, to avoid unrelated `peer` metadata churn from a different npm version.

### Impact assessment

This does **not** fix an exploitable issue here. GHSA-qwww-vcr4-c8h2 is a CSRF bypass in the unstable RSC code paths, and the advisory states it only affects applications using the unstable RSC APIs. `yuno-react` is a client-only Vite SPA: its entire react-router surface is `createBrowserRouter` (4 static routes), `RouterProvider` and `Link`, with no route `action:`, no `<Form>`, no `useFetcher`/`useSubmit`, and no server rendering. SecOps triaged VULS-5385 to the same conclusion: `EXISTENT | UNREACHABLE | NOT EXPLOITABLE — Risk: NONE`.

This is taken as free hygiene: 7.18.2 is a single patch release ("Harden RSC CSRF codepaths", remix-run/react-router#15353) with an identical dependency and peer-dependency set to 7.18.1.

### Note on the Dependabot alert

Alert #300 will **not** auto-close from this bump. The advisory still declares `vulnerableVersionRange: >= 7.12.0, < 8.3.0` with `firstPatchedVersion: 8.3.0`, and has not been updated with the 7.x backport, so 7.18.2 remains inside the flagged range. There is also no `react-router-dom` 8.x line at all (latest is 7.18.2; v8 dropped the `-dom` package), so reaching 8.3.0 would mean a major migration of the demo. Closing the alert therefore needs a manual dismissal as "vulnerable code is not actually used".

### Verification

- `npm ci` installs cleanly from the edited lockfile (integrity hashes validated by npm)
- Installed `react-router` resolves to 7.18.2
- `npm run build` (`tsc -b && vite build`) passes — 88 modules transformed, built in 750ms
- No lockfile drift after `npm ci`
