### PR TITLE
chore:[YSHUB-6308] remove Full checkout paymentMethodType preselection from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,27 +862,6 @@ Finally mount the **SDK** in a `html` element, you can use any valid css selecto
 await yuno.mountCheckout()
 ```
 
-If you need to select a payment method by default, mount it using
-
-```javascript
-/**
- * Mount checkout in browser DOM with a payment method selected by default
- * @optional
- */
-await yuno.mountCheckout({
-  /**
-   * Optional, only needed if you would like this method type selected by default
-   * Can be one of 'BANCOLOMBIA_TRANSFER' | 'PIX' | 'ADDI' | 'NU_PAY' | 'MERCADO_PAGO_CHECKOUT_PRO
-   */
-  paymentMethodType: PAYMENT_METHOD_TYPE,
-  /**
-   * Optional
-   * Vaulted token related to payment method type
-   */
-  vaultedToken: VAULTED_TOKEN,
-})
-```
-
 Remember you need to call 
 ```javascript
 yuno.startPayment()


### PR DESCRIPTION
## Context

Reported in [YSHUB-6308](https://yunopayments.atlassian.net/browse/YSHUB-6308): a merchant followed the README to preselect a payment method in the Full checkout via `mountCheckout({ paymentMethodType: 'PIX' })` and the parameter had no effect — no error, no warning.

## What's wrong

The README documents mounting the Full checkout with a payment method selected by default:

```javascript
await yuno.mountCheckout({
  paymentMethodType: PAYMENT_METHOD_TYPE,
  vaultedToken: VAULTED_TOKEN,
})
```

That behavior did exist, but it was removed in **July 2025**. In the current SDK `mountCheckout()` takes no arguments at all, so the object is silently discarded.

Confirmed with the team that this is **by design**, not a bug. Preselection in the Full checkout is driven by the payment method ordering — enrolled methods first, then the order configured in the Checkout builder — and the first method in the resulting list is the one that gets preselected.

## Change

Removes the incorrect section from the Full checkout docs. The valid `await yuno.mountCheckout()` example right above it is kept.

`paymentMethodType` and `vaultedToken` remain documented where they are still supported — `mountCheckoutLite`, `mountSeamlessCheckoutLite` and the external buttons setup — and those sections are untouched.

## Follow-up (not in this PR)

`typescript/types.ts` still declares `MountCheckoutArgs` with `paymentMethodType`, `vaultedToken` and `category`, plus `mountCheckout(args: MountCheckoutArgs)`. It's a legacy in-repo copy and does not feed the published `@yuno-payments/sdk-web-types` package, which already declares `mountCheckout(): Promise<void>` correctly. Worth cleaning up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[YSHUB-6308]: https://yunopayments.atlassian.net/browse/YSHUB-6308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ