### PR TITLE
docs: bump Web SDK version v1.9 → v1.10.3 in README and vanilla examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -275,7 +275,7 @@ After it is mounted, it will start the desired flow
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -511,7 +511,7 @@ After it is mounted, it will start the desired flow
 To use checkout seamless you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -621,7 +621,7 @@ After it is mounted, it will start the desired flow
 To use full checkout you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -887,7 +887,7 @@ PayButton.addEventListener('click', () => {
 To use checkout lite you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -1171,7 +1171,7 @@ await yuno.clearApiCache()
 To use checkout secure fields you should include our **SDK** file in your page before close your `</body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -1615,7 +1615,7 @@ if (payment.checkout.sdk_action_required) {
 To use status you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -1657,7 +1657,7 @@ await yuno.mountStatusPayment({
 To use status lite you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -1684,7 +1684,7 @@ const status = await yuno.paymentResult(checkoutSession)
 To use enrollment lite you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**
@@ -1860,7 +1860,7 @@ await yuno.mountEnrollmentLite({
 To use enrollment with secure fields you should include our **SDK** file in your page before close your `<body>` tag
 
 ```html
-<script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+<script src="https://sdk-web.y.uno/v1.10.3/main.js"></script>
 ```
 
 Get a `Yuno` instance class in your `JS` app with a valid **PUBLIC_API_KEY**

--- a/vanilla/pages/checkout-lite.html
+++ b/vanilla/pages/checkout-lite.html
@@ -17,6 +17,6 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="../static/checkout-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout-seamless-external-buttons.html
+++ b/vanilla/pages/checkout-seamless-external-buttons.html
@@ -45,7 +45,7 @@
   <button id="mount-paypal-enrollment">Mount PayPal Enrollment</button>
   <button id="mount-apple-pay">Mount Apple Pay</button>
   <button id="mount-google-pay">Mount Google Pay</button>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 
 </html>

--- a/vanilla/pages/checkout-seamless-lite.html
+++ b/vanilla/pages/checkout-seamless-lite.html
@@ -26,7 +26,7 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="/static/checkout-seamless-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 
   <script>
     const canaryToggle = document.getElementById('canary-toggle')

--- a/vanilla/pages/checkout-seamless.html
+++ b/vanilla/pages/checkout-seamless.html
@@ -27,7 +27,7 @@
   <button id="button-pay">Pagar Ahora</button>
 
   <script type="module" src="/static/checkout-seamless.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 
   <script>
     const canaryToggle = document.getElementById('canary-toggle')

--- a/vanilla/pages/checkout-secure-fields.html
+++ b/vanilla/pages/checkout-secure-fields.html
@@ -27,6 +27,6 @@
   <button id="button-pay" disabled style="display: none;">Pay Now</button>
 
   <script type="module" src="/static/checkout-secure-fields.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/checkout.html
+++ b/vanilla/pages/checkout.html
@@ -35,7 +35,7 @@
   <script type="module" src="../static/checkout.js"></script>
   
   <!-- include Yuno SDK -->
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 
   <script>
     const canaryToggle = document.getElementById('canary-toggle')

--- a/vanilla/pages/enrollment-lite.html
+++ b/vanilla/pages/enrollment-lite.html
@@ -26,7 +26,7 @@
   <div id="action-form-element"></div>
 
   <script type="module" src="../static/enrollment-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 
   <script>
     const canaryToggle = document.getElementById('canary-toggle')

--- a/vanilla/pages/index.html
+++ b/vanilla/pages/index.html
@@ -27,6 +27,6 @@
   <!-- White-label sub-path repro (CORECM-17664): load the bundle from the proxy
        under the same base path the SDK is initialized with. -->
   <script src="http://localhost:9090/hosted-payment-methods/hosted-payment-form/orchestrator/v1.0/main.js" defer></script>
-  <!-- <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script> -->
+  <!-- <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script> -->
 </body>
 </html>

--- a/vanilla/pages/payment-methods-unfolded.html
+++ b/vanilla/pages/payment-methods-unfolded.html
@@ -97,7 +97,7 @@
   <div id="root"></div>
 
   <script type="module" src="../static/payment-methods-unfolded.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 
 </html>

--- a/vanilla/pages/status-lite.html
+++ b/vanilla/pages/status-lite.html
@@ -16,6 +16,6 @@
   <div id="root"></div>
 
   <script type="module" src="../static/status-lite.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 </html>

--- a/vanilla/pages/status.html
+++ b/vanilla/pages/status.html
@@ -16,6 +16,6 @@
   <div id="root"></div>
 
   <script type="module" src="../static/status.js"></script>
-  <script src="https://sdk-web.y.uno/v1.9/main.js" defer></script>
+  <script src="https://sdk-web.y.uno/v1.10.3/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Why

Web SDK versions **≤ v1.9** carry a long-standing bug: in **sandbox** flows the 3DS challenge page is requested from the **production** `sdk-3ds` distribution. Since JWT validation on the prod edge moved to enforce mode, every sandbox 3DS challenge on old SDK versions fails with a bare **403 Forbidden** inside the SDK modal (sandbox-minted session JWT cannot validate against prod config). The fix shipped in **SDK 1.10.3** (see internal thread: https://yunopay.slack.com/archives/C03LFFFBW31/p1786104153446589 — confirmed by the SDK team).

Merchants copy the script pin straight from this README and the vanilla examples, so every integration bootstrapped from here lands on v1.9 with a broken sandbox 3DS challenge. Live example: a merchant certification run on 2026-08-10 failed exactly this way (stand on v1.9 / X-Version 13.0.26, challenge iframe → prod domain → 403; same query against `sdk-3ds.sandbox.y.uno` returns 200).

## What

- Replace `https://sdk-web.y.uno/v1.9/main.js` → `https://sdk-web.y.uno/v1.10.3/main.js` everywhere (README + 11 vanilla example pages, 21 occurrences, incl. one commented-out line).

## Verification

- `https://sdk-web.y.uno/v1.10.3/main.js` is live and serves build 1.10.3 (internal `X-Version` 14.0.4).
- `grep -rn 'v1\.9'` over the repo returns 0 hits after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)